### PR TITLE
add grpcio, forbid wheels with incorrect architectures

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -5,6 +5,8 @@
 [distlib==0.3.4]
 [distlib==0.3.5]
 
+[grpcio==1.46.3]
+
 [jmespath==0.10.0]
 
 [lxml==4.6.5]

--- a/packages.ini
+++ b/packages.ini
@@ -6,6 +6,8 @@
 [distlib==0.3.5]
 
 [grpcio==1.46.3]
+ignore_wheels = grpcio-1.46.3-cp310-cp310-macosx_10_10_universal2.whl
+[grpcio==1.47.0]
 
 [jmespath==0.10.0]
 

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import subprocess
 import zipfile
+from unittest import mock
 
 import pytest
 from packaging.tags import parse_tag
@@ -57,3 +59,64 @@ def test_top_import_record(tmp_path):
             )
 
     assert validate._top_import(str(whl)) == "distlib,_distlib_backend,distlib_top"
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    (
+        ("a-1-py3-none-any.whl", set()),
+        ("a-1-py3-none-manylinux2014_x86_64.whl", {"x86_64"}),
+        ("a-1-py3-none-manylinux2014_aarch64.whl", {"aarch64"}),
+        ("a-1-py3-none-macosx_11_0_intel.whl", {"x86_64"}),
+        ("a-1-py3-none-macosx_11_0_arm64.whl", {"arm64"}),
+        ("a-1-py3-none-macosx_11_0_universal2.whl", {"x86_64", "arm64"}),
+        (
+            "a-1-py3-none-macosx_11_0_x86_64.macosx_11_0_arm64.whl",
+            {"x86_64", "arm64"},
+        ),
+    ),
+)
+def test_expected_archs_for_wheel(filename, expected):
+    assert validate._expected_archs_for_wheel(filename) == expected
+
+
+def test_get_archs_darwin_single_arch():
+    out = b"""\
+./simplejson/_speedups.cpython-38-darwin.so:
+Mach header
+      magic  cputype cpusubtype  caps    filetype ncmds sizeofcmds      flags
+MH_MAGIC_64    ARM64        ALL  0x00      BUNDLE    14       1416   NOUNDEFS DYLDLINK TWOLEVEL
+"""
+    with mock.patch.object(subprocess, "check_output", return_value=out):
+        assert validate._get_archs_darwin("somefile.so") == {"arm64"}
+
+
+def test_get_archs_darwin_multi_arch():
+    out = b"""\
+./google_crc32c/_crc32c.cpython-38-darwin.so (architecture x86_64):
+Mach header
+      magic  cputype cpusubtype  caps    filetype ncmds sizeofcmds      flags
+MH_MAGIC_64   X86_64        ALL  0x00      BUNDLE    14       1312   NOUNDEFS DYLDLINK TWOLEVEL
+./google_crc32c/_crc32c.cpython-38-darwin.so (architecture arm64):
+Mach header
+      magic  cputype cpusubtype  caps    filetype ncmds sizeofcmds      flags
+MH_MAGIC_64    ARM64        ALL  0x00      BUNDLE    15       1320   NOUNDEFS DYLDLINK TWOLEVEL
+"""
+    with mock.patch.object(subprocess, "check_output", return_value=out):
+        assert validate._get_archs_darwin("somefile.so") == {"arm64", "x86_64"}
+
+
+def test_get_archs_linux_x86_64():
+    out = b"""\
+venv/bin/uwsgi: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, BuildID[sha1]=be830dfcdbb9a7a90cf0687ba4cecde8951db1e0, for GNU/Linux 3.2.0, with debug_info, not stripped
+"""
+    with mock.patch.object(subprocess, "check_output", return_value=out):
+        assert validate._get_archs_linux("somefile.so") == {"x86_64"}
+
+
+def test_get_archs_linux_aarch64():
+    out = b"""\
+simplejson/_speedups.cpython-37m-aarch64-linux-gnu.so: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, BuildID[sha1]=77175a0e0fc131e1ad0f84daaaaee89c5f89c5b0, with debug_info, not stripped
+"""
+    with mock.patch.object(subprocess, "check_output", return_value=out):
+        assert validate._get_archs_linux("somefile.so") == {"aarch64"}

--- a/validate.py
+++ b/validate.py
@@ -12,6 +12,7 @@ from packaging.tags import Tag
 from packaging.utils import parse_wheel_filename
 
 DIST_INFO_RE = re.compile(r"^[^/]+.dist-info/[^/]+$")
+DATA_SCRIPTS = re.compile(r"^[^/]+.data/scripts/[^/]+$")
 
 
 def _pythons_to_check(tags: frozenset[Tag]) -> tuple[str, ...]:
@@ -56,9 +57,87 @@ def _top_import(whl: str) -> str:
             raise NotImplementedError("need top_level.txt or RECORD")
 
 
+def _expected_archs_for_wheel(filename: str) -> set[str]:
+    archs = set()
+    parts = os.path.splitext(os.path.basename(filename))[0].split("-")
+    for plat in parts[-1].split("."):
+        if plat == "any":
+            continue
+        elif plat.endswith("_intel"):  # macos
+            archs.add("x86_64")
+        elif plat.endswith("_universal2"):  # macos
+            archs.update(("x86_64", "arm64"))
+        else:
+            for arch in ("aarch64", "arm64", "x86_64"):
+                if plat.endswith(f"_{arch}"):
+                    archs.add(arch)
+                    break
+            else:
+                raise AssertionError(f"unexpected {plat=}")
+
+    return archs
+
+
+def _get_archs_darwin(file: str) -> set[str]:
+    out = subprocess.check_output(("otool", "-hv", "-arch", "all", file))
+    lines = out.decode().splitlines()
+    if len(lines) % 4 != 0:
+        raise AssertionError(f"unexpected otool output:\n{lines}")
+
+    return {
+        line.split()[1].lower()
+        # output is in chunks of 4, we care about the 4th in each chunk
+        for line in lines[3::4]
+    }
+
+
+def _get_archs_linux(file: str) -> set[str]:
+    # TODO: this could be more accurate
+    out = subprocess.check_output(("file", file)).decode()
+    if ", x86-64," in out:
+        return {"x86_64"}
+    elif ", ARM aarch64," in out:
+        return {"aarch64"}
+    else:
+        raise AssertionError(f"unknown architecture {file=}")
+
+
+if sys.platform == "darwin":  # pragma: darwin cover
+    _get_archs = _get_archs_darwin
+else:  # pragma: darwin no cover
+    _get_archs = _get_archs_linux
+
+
 def _validate(python: str, filename: str, index_url: str) -> None:
     print(f"validating {python}: {filename}")
     with tempfile.TemporaryDirectory() as tmpdir:
+        print("checking arch")
+        archdir = os.path.join(tmpdir, "arch")
+        with zipfile.ZipFile(filename) as zipf:
+            arch_files = []
+            for name in zipf.namelist():
+                if name.endswith((".so", ".dylib")) or ".so." in name:
+                    arch_files.append(name)
+                elif DATA_SCRIPTS.match(name):
+                    with zipf.open(name) as f:
+                        if f.read(2) != b"#!":
+                            arch_files.append(name)
+
+            for arch_file in arch_files:
+                zipf.extract(arch_file, archdir)
+
+        archs = _expected_archs_for_wheel(filename)
+        for arch_file in arch_files:
+            archs_for_file = _get_archs(os.path.join(archdir, arch_file))
+            if archs_for_file != archs:
+                raise SystemExit(
+                    f"-> {arch_file} has mismatched architectures\n"
+                    f"---> you may be able to fix this with `ignore_wheels = {os.path.basename(filename)}`\n"
+                    f'---> expected {", ".join(sorted(archs))}\n'
+                    f'---> received {", ".join(sorted(archs_for_file))}\n'
+                )
+
+        print("creating env")
         venv = os.path.join(tmpdir, "venv")
         py = os.path.join(venv, "bin", "python")
 


### PR DESCRIPTION
example output from architecture detection:

```
validating python3.10: dist/grpcio-1.46.3-cp310-cp310-macosx_10_10_universal2.whl
checking arch
-> grpc/_cython/cygrpc.cpython-310-darwin.so has mismatched architectures
---> you may be able to fix this with `ignore_wheels = grpcio-1.46.3-cp310-cp310-macosx_10_10_universal2.whl`
---> expected arm64, x86_64
---> received x86_64
```