### PR TITLE
serialize workflow runs of index build on the primary branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main, test-me-*]
 
+concurrency:
+  # serialize runs on the default branch
+  group: ${{ github.event_name == 'push' && github.workflow || github.sha }}
+
 jobs:
   linux:
     runs-on: ubuntu-latest

--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -6,6 +6,10 @@ on:
     branches: [main, test-me-*]
     paths: [docker/*, .github/workflows/image.yml]
 
+concurrency:
+  # serialize runs on the default branch
+  group: ${{ github.event_name == 'push' && github.workflow || github.sha }}
+
 jobs:
   image:
     strategy:


### PR DESCRIPTION
tried this out in my scratch repo -- main branch commits run serially, PRs can run concurrently