### PR TITLE
allow format_ini to remove duplicate names

### DIFF
--- a/format_ini.py
+++ b/format_ini.py
@@ -33,7 +33,7 @@ def _format_file(filename: str) -> int:
     with open(filename, encoding="UTF-8", newline="") as f:
         contents = f.read()
 
-    orig = configparser.RawConfigParser()
+    orig = configparser.RawConfigParser(strict=False)
     orig.read_string(contents)
 
     errors = []

--- a/tests/format_ini_test.py
+++ b/tests/format_ini_test.py
@@ -119,3 +119,22 @@ brew_requires = librdkafka
 
     _, err = capsys.readouterr()
     assert err == f"{ini}: formatted\n"
+
+
+def test_removes_duplicates(capsys, tmp_path):
+    ini_src = """\
+[simplejson==3.17.2]
+[simplejson==3.17.2]
+"""
+    expected = """\
+[simplejson==3.17.2]
+"""
+    ini = tmp_path.joinpath("f.ini")
+    ini.write_text(ini_src)
+
+    assert format_ini.main((str(ini),)) == 1
+
+    assert ini.read_text() == expected
+
+    _, err = capsys.readouterr()
+    assert err == f"{ini}: formatted\n"


### PR DESCRIPTION
this makes it much easier to resolve conflicts and paste a bunch of new packages