### PR TITLE
add build scripts for google-crc32c

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,19 @@ brew_requires =
 some packages on pypi have incorrectly built wheels -- these can be ignored (forcing them to
 be built rather than imported):
 
+### custom_prebuild
+
+sometimes the dependencies aren't packaged for apt / brew and you need a custom
+script to set them up.  this script will be passed a single "prefix" directory
+(which contains the standard `bin` / `lib` / `include` / etc. structure).
+
+the script should set up whatever tools are necessary inside only that directory
+
+```ini
+[google-crc32c==1.3.0]
+custom_prebuild = prebuild/crc32c 1.1.2
+```
+
 ### ignore_wheels
 
 ```ini

--- a/format_ini.py
+++ b/format_ini.py
@@ -10,6 +10,8 @@ from typing import Sequence
 from packaging.utils import canonicalize_name
 from packaging.version import Version
 
+_NO_FORMAT = {"custom_prebuild"}
+
 _PKG_RE = re.compile("^.*==.*$")
 _TRAILING_WS = re.compile(" +\n")
 
@@ -54,7 +56,10 @@ def _format_file(filename: str) -> int:
         cfg.add_section(newsection)
 
         for k, v in sorted(orig[section].items()):
-            cfg[newsection][k] = _format_value(v)
+            if k not in _NO_FORMAT:
+                cfg[newsection][k] = _format_value(v)
+            else:
+                cfg[newsection][k] = v
 
     cfg_sio = io.StringIO()
     cfg.write(cfg_sio)

--- a/packages.ini
+++ b/packages.ini
@@ -62,6 +62,11 @@ validate_incorrect_missing_deps = six
 
 [frozenlist==1.3.1]
 
+[google-crc32c==1.3.0]
+apt_requires = cmake
+brew_requires = cmake
+custom_prebuild = prebuild/crc32c 1.1.2
+
 [grpcio==1.46.3]
 ignore_wheels = grpcio-1.46.3-cp310-cp310-macosx_10_10_universal2.whl
 [grpcio==1.47.0]

--- a/prebuild/crc32c
+++ b/prebuild/crc32c
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os.path
+import subprocess
+import tempfile
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("crc32c_rev")
+    parser.add_argument("prefix")
+    args = parser.parse_args()
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        print("cloning crc32c...")
+        subprocess.check_call(
+            (
+                "git",
+                "clone",
+                "--quiet",
+                "https://github.com/google/crc32c",
+                tmpdir,
+            ),
+        )
+        subprocess.check_call(
+            ("git", "-C", tmpdir, "checkout", "--quiet", args.crc32c_rev)
+        )
+
+        print("checking out submodules...")
+        subprocess.check_call(
+            (
+                "git",
+                "-C",
+                tmpdir,
+                "submodule",
+                "update",
+                "--quiet",
+                "--init",
+                "--recursive",
+                "--depth=1",
+            )
+        )
+
+        print("building...")
+        build_dir = os.path.join(tmpdir, "build")
+        os.makedirs(build_dir)
+        subprocess.check_call(
+            (
+                "cmake",
+                f"-DCMAKE_INSTALL_PREFIX={args.prefix}",
+                "-DCRC32C_BUILD_TESTS=no",
+                "-DCRC32C_BUILD_BENCHMARKS=no",
+                "-DBUILD_SHARED_LIBS=yes",
+                "..",
+            ),
+            cwd=build_dir,
+        )
+        subprocess.check_call(("make", "all", "install"), cwd=build_dir)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/format_ini_test.py
+++ b/tests/format_ini_test.py
@@ -138,3 +138,21 @@ def test_removes_duplicates(capsys, tmp_path):
 
     _, err = capsys.readouterr()
     assert err == f"{ini}: formatted\n"
+
+
+def test_does_not_reformat_custom_prebuild(capsys, tmp_path):
+    ini_src = """\
+[google-crc32c==1.3.0]
+apt_requires = cmake
+brew_requires = cmake
+custom_prebuild = prebuild/crc32 1.1.2
+"""
+    ini = tmp_path.joinpath("f.ini")
+    ini.write_text(ini_src)
+
+    assert format_ini.main((str(ini),)) == 0
+
+    assert ini.read_text() == ini_src
+
+    _, err = capsys.readouterr()
+    assert err == ""

--- a/validate.py
+++ b/validate.py
@@ -153,7 +153,7 @@ def _validate(
         archs = _expected_archs_for_wheel(filename)
         for arch_file in arch_files:
             archs_for_file = _get_archs(os.path.join(archdir, arch_file))
-            if archs_for_file != archs:
+            if (archs & archs_for_file) != archs:
                 raise SystemExit(
                     f"-> {arch_file} has mismatched architectures\n"
                     f"---> you may be able to fix this with `ignore_wheels = {os.path.basename(filename)}`\n"


### PR DESCRIPTION
`crc32c` is a google project that isn't packaged for `apt` -- this mimicks the installation instructions here: https://github.com/googleapis/python-crc32c/blob/9be2d165b3ed7861e5329c305ab192d65b61b18f/scripts/manylinux/build_on_centos.sh

I needed to pick a newer version of `crc32c` as the one that was being used doesn't build on `arm64`