### PR TITLE
ignore un-shebanged .py "scripts" in arch check

### DIFF
--- a/build.py
+++ b/build.py
@@ -37,7 +37,7 @@ BINARY_EXTS = frozenset(
     (".c", ".cc", ".cpp", ".cxx", ".pxd", ".pxi", ".pyx", ".go", ".rs")
 )
 
-DATA_SCRIPTS = re.compile(r"^[^/]+.data/scripts/[^/]+$")
+DATA_SCRIPTS = re.compile(r"^[^/]+.data/scripts/[^/]+(?<!\.py)$")
 
 
 def _supported_tags(version: tuple[int, int]) -> frozenset[Tag]:

--- a/packages.ini
+++ b/packages.ini
@@ -25,6 +25,8 @@ validate_extras = d
 
 [build==0.8.0]
 
+[cachetools==4.2.4]
+
 [certifi==2022.5.18.1]
 [certifi==2022.6.15]
 
@@ -33,6 +35,8 @@ apt_requires = libffi-dev
 brew_requires = libffi
 
 [cfgv==3.3.1]
+
+[chardet==4.0.0]
 
 [charset-normalizer==2.0.12]
 [charset-normalizer==2.1.0]
@@ -97,10 +101,20 @@ validate_incorrect_missing_deps = six
 
 [frozenlist==1.3.1]
 
+[google-api-core==1.32.0]
+
+[google-auth==1.35.0]
+
+[google-cloud-pubsub==2.2.0]
+
 [google-crc32c==1.3.0]
 apt_requires = cmake
 brew_requires = cmake
 custom_prebuild = prebuild/crc32c 1.1.2
+
+[googleapis-common-protos==1.56.2]
+
+[grpc-google-iam-v1==0.12.4]
 
 [grpcio==1.46.3]
 [grpcio==1.47.0]
@@ -115,6 +129,7 @@ custom_prebuild = prebuild/crc32c 1.1.2
 [identify==2.5.1]
 [identify==2.5.3]
 
+[idna==2.10]
 [idna==3.3]
 
 [importlib-metadata==3.10.1]
@@ -238,6 +253,8 @@ brew_requires = libmaxminddb
 
 [progressbar2==4.0.0]
 
+[proto-plus==1.20.4]
+
 [protobuf==3.19.0]
 [protobuf==4.21.5]
 
@@ -253,6 +270,10 @@ brew_requires =
     postgresql
 
 [py==1.11.0]
+
+[pyasn1==0.4.5]
+
+[pyasn1-modules==0.2.4]
 
 [pycodestyle==2.8.0]
 [pycodestyle==2.9.0]
@@ -295,6 +316,7 @@ brew_requires =
 
 [python-utils==3.3.3]
 
+[pytz==2018.9]
 [pytz==2022.1]
 [pytz==2022.2]
 
@@ -315,10 +337,13 @@ brew_requires = libyaml
 
 [regex==2022.7.25]
 
+[requests==2.25.1]
 [requests==2.27.1]
 [requests==2.28.1]
 
 [responses==0.21.0]
+
+[rsa==4.8]
 
 [s3transfer==0.5.2]
 [s3transfer==0.6.0]
@@ -331,6 +356,7 @@ brew_requires = libyaml
 [sentry-sdk==1.9.3]
 [sentry-sdk==1.9.4]
 
+[setuptools==56.0.0]
 [setuptools==62.3.2]
 [setuptools==63.4.1]
 [setuptools==63.4.2]

--- a/tests/build_test.py
+++ b/tests/build_test.py
@@ -19,6 +19,19 @@ from build import Package
 from build import Wheel
 
 
+@pytest.mark.parametrize(
+    ("s", "matched"),
+    (
+        ("a-1.data/scripts/uwsgi", True),
+        ("a-1.data/scripts/run_thing.py", False),
+        ("a-1.data/purelib/unrelated", False),
+        ("scripts/unrelated", False),
+    ),
+)
+def test_data_scripts_re(s, matched):
+    assert bool(build.DATA_SCRIPTS.fullmatch(s)) is matched
+
+
 @pytest.mark.parametrize("ext", sorted(build.BINARY_EXTS))
 def test_all_binary_exts_start_with_dot(ext):
     assert ext.startswith(".")


### PR DESCRIPTION
before this it was failing with:

```
=== google-cloud-pubsub==2.2.0@(3, 8)
-> building...
Traceback (most recent call last):
  File "/opt/python/cp38-cp38/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/opt/python/cp38-cp38/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/src/build.py", line 633, in <module>
    raise SystemExit(main())
  File "/src/build.py", line 620, in main
    downloaded_wheel = _download(package, python, args.dest)
  File "/src/build.py", line 398, in _download
    arch_reason = _check_arch(filename_full)
  File "/src/build.py", line 362, in _check_arch
    archs_for_file = plat.get_archs(os.path.join(archdir, arch_file))
  File "/src/build.py", line 280, in _linux_get_archs
    raise AssertionError(f"unknown architecture {file=}")
AssertionError: unknown architecture file='/tmp/tmpm84m911f/arch/google_cloud_pubsub-2.2.0.data/scripts/fixup_pubsub_v1_keywords.py'
```