### PR TITLE
add maxminddb

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -145,6 +145,13 @@ brew_requires =
 
 [markupsafe==2.1.1]
 
+[maxminddb==2.0.3]
+apt_requires = libmaxminddb-dev
+brew_requires = libmaxminddb
+[maxminddb==2.2.0]
+apt_requires = libmaxminddb-dev
+brew_requires = libmaxminddb
+
 [mccabe==0.6.1]
 [mccabe==0.7.0]
 


### PR DESCRIPTION
this package has some special binary dependencies -- but fortunately the build scripts did their job!

```
=== maxminddb==2.0.3@(3, 8)
-> building...
Collecting maxminddb==2.0.3
  Downloading maxminddb-2.0.3.tar.gz (286 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 286.1/286.1 kB 8.4 MB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Saved /tmp/tmp_yqg407l/sdist/maxminddb-2.0.3.tar.gz
Successfully downloaded maxminddb
Looking in indexes: https://pypi.devinfra.sentry.io/simple
Processing /tmp/tmp_yqg407l/sdist/maxminddb-2.0.3.tar.gz
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'done'
Building wheels for collected packages: maxminddb
  Building wheel for maxminddb (setup.py): started
  Building wheel for maxminddb (setup.py): finished with status 'done'
  Created wheel for maxminddb: filename=maxminddb-2.0.3-py2.py3-none-any.whl size=15282 sha256=ee2b903960ca7cea6bb92ba5c1ece09f88bb5cab4c5e08774d0672270b47dd98
  Stored in directory: /tmp/pip-ephem-wheel-cache-cmzordir/wheels/45/a2/5a/5ff354a8a9eee156c7c5a5250adf52e5a162906a54de21c544
Successfully built maxminddb
maxminddb==2.0.3 expected binary as sdist contains files with these extensions: .c
```