### PR TITLE
ignore top_level.txt as it is not always accurate

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -56,6 +56,9 @@ custom_prebuild = prebuild/librdkafka v1.9.2
 [coverage==6.4.1]
 [coverage==6.4.3]
 
+[cryptography==37.0.2]
+[cryptography==37.0.4]
+
 [cython==0.29.32]
 
 [datadog==0.21.0]

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -66,15 +66,6 @@ def test_pythons_to_check_specific_cpython_tag():
     assert ret == ("python3.8",)
 
 
-def test_top_imports_top_level_txt(tmp_path):
-    whl = tmp_path.joinpath("cffi.whl")
-    with zipfile.ZipFile(whl, "w") as zipf:
-        with zipf.open("cffi-1.15.1.dist-info/top_level.txt", "w") as f:
-            f.write(b"_cffi_backend\ncffi\n")
-
-    assert validate._top_imports(str(whl)) == ["_cffi_backend", "cffi"]
-
-
 def test_top_imports_record(tmp_path):
     whl = tmp_path.joinpath("distlib.whl")
     with zipfile.ZipFile(whl, "w") as zipf:

--- a/validate.py
+++ b/validate.py
@@ -69,10 +69,7 @@ def _top_imports(whl: str) -> list[str]:
             for name in zipf.namelist()
             if DIST_INFO_RE.match(name)
         }
-        if "top_level.txt" in dist_info_names:
-            with zipf.open(dist_info_names["top_level.txt"]) as f:
-                return f.read().decode().splitlines()
-        elif "RECORD" in dist_info_names:
+        if "RECORD" in dist_info_names:
             with zipf.open(dist_info_names["RECORD"]) as f:
                 pkgs = {}
                 for line_b in f:
@@ -83,7 +80,7 @@ def _top_imports(whl: str) -> list[str]:
                         pkgs[fname.split(".")[0]] = 1
                 return list(pkgs)
         else:
-            raise NotImplementedError("need top_level.txt or RECORD")
+            raise NotImplementedError("need RECORD")
 
 
 def _validate(


### PR DESCRIPTION
cryptography has an incorrect `top_level.txt` due to a setuptools bug