### PR TITLE
Revert "add uwsgi-dogstatsd-plugin"

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -548,8 +548,6 @@ validate_incorrect_missing_deps = beautifulsoup4
 [urllib3==1.26.10]
 [urllib3==1.26.11]
 
-[uwsgi-dogstatsd-plugin==1.0.0]
-
 [vine==1.3.0]
 
 [virtualenv==20.14.1]


### PR DESCRIPTION
Reverts getsentry/pypi#57

this doesn't actually remove the package -- but this package doesn't work properly