### PR TITLE
build legacy 10.x wheels for intel macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,11 @@ jobs:
         path: dist/*
   macos:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        version-compat: [0, 1]
+    env:
+      SYSTEM_VERSION_COMPAT: ${{ matrix.version-compat }}
     steps:
     - uses: actions/checkout@v3
     - run: python3 -u docker/install-pythons --dest pythons
@@ -35,7 +40,7 @@ jobs:
     - run: python3 -um validate --index-url https://pypi.devinfra.sentry.io/simple
     - uses: actions/upload-artifact@v3
       with:
-        name: dist-macos
+        name: dist-macos-${{ matrix.version-compat }}
         path: dist/*
 
   cirrus:

--- a/build.py
+++ b/build.py
@@ -185,7 +185,10 @@ def _darwin_install(package: Package) -> Generator[None, None, None]:
 
 
 def _darwin_get_archs(file: str) -> set[str]:
-    out = subprocess.check_output(("otool", "-hv", "-arch", "all", file))
+    cmd = ("otool", "-hv", "-arch", "all", file)
+    # `otool` crashes when presented with this environment variable
+    env = {k: v for k, v in os.environ.items() if k != "SYSTEM_VERSION_COMPAT"}
+    out = subprocess.check_output(cmd, env=env)
     lines = out.decode().splitlines()
     if len(lines) % 4 != 0:
         raise AssertionError(f"unexpected otool output:\n{lines}")


### PR DESCRIPTION
the environment variable in this PR does peculiar things:

- for pythons compiled on macos<11 by default they will report `platform.mac_ver()` of 10.16 even on macos 11+
- for pythons compiled on macos>=11 by default they will report `platform.mac_ver()` of the actual macos version
- with `SYSTEM_VERSION_COMPAT=0` they will consistently report the actual mac version
- with `SYSTEM_VERSION_COMPAT=1` they will consistently report 10.16