### PR TITLE
feat: add ops requirements except salt

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -27,6 +27,8 @@
 [backports-zoneinfo==0.2.1]
 python_versions = <3.9
 
+[bcrypt==4.0.0]
+
 [beautifulsoup4==4.7.1]
 [beautifulsoup4==4.11.1]
 
@@ -60,6 +62,7 @@ validate_extras = d
 
 [certifi==2022.5.18.1]
 [certifi==2022.6.15]
+[certifi==2022.6.15.1]
 
 [cffi==1.15.1]
 apt_requires = libffi-dev
@@ -104,6 +107,7 @@ custom_prebuild = prebuild/librdkafka v1.9.2
 
 [cryptography==37.0.2]
 [cryptography==37.0.4]
+[cryptography==38.0.1]
 
 [cssselect==1.0.3]
 [cssselect==1.1.0]
@@ -190,6 +194,7 @@ validate_incorrect_missing_deps = six
 [google-api-core==1.32.0]
 [google-api-core==2.8.2]
 
+[google-auth==1.29.0]
 [google-auth==1.35.0]
 [google-auth==2.11.0]
 
@@ -229,6 +234,7 @@ custom_prebuild = prebuild/crc32c 1.1.2
 
 [grpcio-status==1.47.0]
 
+[h11==0.9.0]
 [h11==0.13.0]
 
 [hiredis==0.3.1]
@@ -237,6 +243,10 @@ custom_prebuild = prebuild/crc32c 1.1.2
 [honcho==1.0.0]
 [honcho==1.0.1]
 [honcho==1.1.0]
+
+[httpcore==0.11.1]
+
+[httpx==0.15.4]
 
 [identify==2.5.1]
 [identify==2.5.3]
@@ -262,6 +272,7 @@ custom_prebuild = prebuild/crc32c 1.1.2
 
 [itsdangerous==2.1.2]
 
+[jinja2==3.0.3]
 [jinja2==3.1.2]
 
 [jmespath==0.10.0]
@@ -275,6 +286,10 @@ custom_prebuild = prebuild/crc32c 1.1.2
 
 [kombu==4.6.11]
 [kombu==5.2.4]
+
+[kubernetes==19.15.0]
+
+[lark-parser==0.10.1]
 
 [lazy-object-proxy==1.7.1]
 
@@ -341,6 +356,7 @@ brew_requires = libmaxminddb
 
 [oauthlib==3.1.0]
 [oauthlib==3.2.0]
+[oauthlib==3.2.1]
 
 [openapi-core==0.14.2]
 
@@ -353,6 +369,8 @@ brew_requires = libmaxminddb
 [outcome==1.2.0]
 
 [packaging==21.3]
+
+[paramiko==2.11.0]
 
 [parse==1.19.0]
 
@@ -406,6 +424,8 @@ brew_requires = libmaxminddb
 [protobuf==3.19.0]
 [protobuf==4.21.5]
 
+[psutil==5.9.2]
+
 [psycopg2-binary==2.8.6]
 apt_requires = libpq-dev
 brew_requires =
@@ -444,6 +464,8 @@ brew_requires =
 
 [pyjwt==2.4.0]
 
+[pynacl==1.5.0]
+
 [pyopenssl==22.0.0]
 
 [pyparsing==3.0.9]
@@ -474,6 +496,8 @@ brew_requires =
 
 [python-dateutil==2.8.1]
 [python-dateutil==2.8.2]
+
+[python-hcl2==2.0.3]
 
 [python-memcached==1.59]
 
@@ -538,6 +562,8 @@ brew_requires = libyaml
 [rfc3339-validator==0.1.2]
 [rfc3339-validator==0.1.4]
 
+[rfc3986==1.5.0]
+
 [rfc3986-validator==0.1.1]
 
 [rsa==4.8]
@@ -578,6 +604,7 @@ brew_requires = libyaml
 [six==1.16.0]
 
 [sniffio==1.2.0]
+[sniffio==1.3.0]
 
 [snowballstemmer==2.2.0]
 
@@ -606,6 +633,8 @@ validate_incorrect_missing_deps = beautifulsoup4
 [sqlparse==0.3.0]
 [sqlparse==0.4.2]
 
+[sshuttle==1.0.5]
+
 [statsd==3.3.0]
 
 [stripe==2.61.0]
@@ -616,6 +645,8 @@ validate_incorrect_missing_deps = beautifulsoup4
 
 [symbolic==8.7.1]
 [symbolic==9.1.1]
+
+[tabulate==0.8.9]
 
 [tokenize-rt==4.2.1]
 
@@ -695,6 +726,7 @@ validate_incorrect_missing_deps = beautifulsoup4
 [websocket-client==1.3.2]
 [websocket-client==1.3.3]
 [websocket-client==1.4.0]
+[websocket-client==1.4.1]
 
 [werkzeug==2.0.3]
 [werkzeug==2.1.2]


### PR DESCRIPTION
This is the requirements.txt portion of https://github.com/getsentry/ops/pull/5255. No salt dependency which is a huge one.