### PR TITLE
feat: salt==v3005 for ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ the script should set up whatever tools are necessary inside only that directory
 custom_prebuild = prebuild/crc32c 1.1.2
 ```
 
+### likely_binary_ignore
+
+when the sdist has source files of a compiled language (see BINARY_EXTS),
+we would expect compiled things (e.g. binary executables, shared objects)
+in the wheel. sometimes this isn't the case, and you can ignore those
+source files:
+
+
+```ini
+[salt-ssh==3005]
+likely_binary_ignore =
+    pkg/smartos/esky/sodium_grabber.c
+```
+
 ### python_versions
 
 some packages are only intended for particular python versions (or don't

--- a/packages.ini
+++ b/packages.ini
@@ -623,6 +623,7 @@ brew_requires = libyaml
 [s3transfer==0.6.0]
 
 [salt-ssh==3005]
+likely_binary_ignore = pkg/smartos/esky/sodium_grabber.c
 
 [selenium==4.3.0]
 [selenium==4.4.3]

--- a/packages.ini
+++ b/packages.ini
@@ -7,6 +7,8 @@
 [amqp==2.6.1]
 [amqp==5.1.1]
 
+[apache-libcloud==2.5.0]
+
 [asgiref==3.5.2]
 
 [async-generator==1.10]
@@ -64,18 +66,26 @@ validate_extras = d
 [certifi==2022.6.15]
 [certifi==2022.6.15.1]
 
+[cffi==1.14.6]
+apt_requires = libffi-dev
+brew_requires = libffi
 [cffi==1.15.1]
 apt_requires = libffi-dev
 brew_requires = libffi
 
 [cfgv==3.3.1]
 
+[chardet==3.0.4]
 [chardet==4.0.0]
 [chardet==5.0.0]
 
 [charset-normalizer==2.0.12]
 [charset-normalizer==2.1.0]
 [charset-normalizer==2.1.1]
+
+[cheroot==8.5.2]
+
+[cherrypy==18.6.1]
 
 [click==8.0.4]
 [click==8.1.3]
@@ -97,6 +107,8 @@ apt_requires =
 brew_requires = wget
 custom_prebuild = prebuild/librdkafka v1.9.2
 
+[contextvars==2.4]
+
 [coverage==6.3.3]
 [coverage==6.4.1]
 [coverage==6.4.3]
@@ -105,6 +117,7 @@ custom_prebuild = prebuild/librdkafka v1.9.2
 [croniter==0.3.37]
 [croniter==1.3.5]
 
+[cryptography==3.3.2]
 [cryptography==37.0.2]
 [cryptography==37.0.4]
 [cryptography==38.0.1]
@@ -133,6 +146,8 @@ validate_incorrect_missing_deps = six
 [distlib==0.3.4]
 [distlib==0.3.5]
 [distlib==0.3.6]
+
+[distro==1.5.0]
 
 [django==2.2.28]
 [django==4.1]
@@ -190,6 +205,10 @@ validate_incorrect_missing_deps = six
 [freezegun==1.2.2]
 
 [frozenlist==1.3.1]
+
+[gitdb==4.0.5]
+
+[gitpython==3.1.12]
 
 [google-api-core==1.32.0]
 [google-api-core==2.8.2]
@@ -251,12 +270,16 @@ custom_prebuild = prebuild/crc32c 1.1.2
 [identify==2.5.1]
 [identify==2.5.3]
 
+[idna==2.8]
 [idna==2.10]
 [idna==3.3]
 
 [imagesize==1.4.1]
 
+[immutables==0.15]
+
 [importlib-metadata==3.10.1]
+[importlib-metadata==4.6.4]
 [importlib-metadata==4.12.0]
 
 [importlib-resources==5.8.0]
@@ -272,7 +295,16 @@ custom_prebuild = prebuild/crc32c 1.1.2
 
 [itsdangerous==2.1.2]
 
+[jaraco-classes==3.2.1]
+
+[jaraco-collections==3.4.0]
+
+[jaraco-functools==2.0]
+
+[jaraco-text==3.5.1]
+
 [jinja2==3.0.3]
+[jinja2==3.1.0]
 [jinja2==3.1.2]
 
 [jmespath==0.10.0]
@@ -296,6 +328,8 @@ custom_prebuild = prebuild/crc32c 1.1.2
 [libcst==0.4.3]
 [libcst==0.4.7]
 
+[linode-python==1.1.1]
+
 [lxml==4.6.5]
 apt_requires =
     libxml2-dev
@@ -311,9 +345,12 @@ brew_requires =
     libxml2
     libxslt
 
+[mako==1.1.4]
+
 [markdown==3.3.7]
 [markdown==3.4.1]
 
+[markupsafe==2.0.1]
 [markupsafe==2.1.1]
 
 [maxminddb==2.0.3]
@@ -334,9 +371,11 @@ brew_requires = libmaxminddb
 
 [mock==4.0.3]
 
+[more-itertools==8.2.0]
 [more-itertools==8.13.0]
 [more-itertools==8.14.0]
 
+[msgpack==1.0.2]
 [msgpack==1.0.4]
 
 [msgpack-types==0.2.0]
@@ -410,6 +449,8 @@ brew_requires = libmaxminddb
 [pluggy==0.13.1]
 [pluggy==1.0.0]
 
+[portend==2.6]
+
 [pre-commit==2.18.1]
 [pre-commit==2.20.0]
 
@@ -424,6 +465,7 @@ brew_requires = libmaxminddb
 [protobuf==3.19.0]
 [protobuf==4.21.5]
 
+[psutil==5.8.0]
 [psutil==5.9.2]
 
 [psycopg2-binary==2.8.6]
@@ -454,6 +496,8 @@ brew_requires =
 
 [pycparser==2.21]
 
+[pycryptodomex==3.9.8]
+
 [pyelftools==0.28]
 [pyelftools==0.29]
 
@@ -466,6 +510,7 @@ brew_requires =
 
 [pynacl==1.5.0]
 
+[pyopenssl==19.0.0]
 [pyopenssl==22.0.0]
 
 [pyparsing==3.0.9]
@@ -494,8 +539,11 @@ brew_requires =
 [pytest-xdist==2.4.0]
 [pytest-xdist==2.5.0]
 
+[python-dateutil==2.8.0]
 [python-dateutil==2.8.1]
 [python-dateutil==2.8.2]
+
+[python-gnupg==0.4.8]
 
 [python-hcl2==2.0.3]
 
@@ -535,6 +583,8 @@ brew_requires = libyaml
 apt_requires = libyaml-dev
 brew_requires = libyaml
 
+[pyzmq==23.2.0]
+
 [rb==1.9.0]
 
 [redis==3.4.1]
@@ -572,6 +622,8 @@ brew_requires = libyaml
 [s3transfer==0.5.2]
 [s3transfer==0.6.0]
 
+[salt-ssh==3005]
+
 [selenium==4.3.0]
 [selenium==4.4.3]
 
@@ -588,6 +640,8 @@ brew_requires = libyaml
 [sentry-sdk==1.9.5]
 [sentry-sdk==1.9.8]
 
+[setproctitle==1.1.10]
+
 [setuptools==56.0.0]
 [setuptools==62.3.2]
 [setuptools==63.1.0]
@@ -602,6 +656,8 @@ brew_requires = libyaml
 [simplejson==3.17.6]
 
 [six==1.16.0]
+
+[smmap==3.0.2]
 
 [sniffio==1.2.0]
 [sniffio==1.3.0]
@@ -647,6 +703,10 @@ validate_incorrect_missing_deps = beautifulsoup4
 [symbolic==9.1.1]
 
 [tabulate==0.8.9]
+
+[tempora==4.1.1]
+
+[timelib==0.2.5]
 
 [tokenize-rt==4.2.1]
 
@@ -707,6 +767,7 @@ validate_incorrect_missing_deps = beautifulsoup4
 
 [uritemplate==4.1.1]
 
+[urllib3==1.26.6]
 [urllib3==1.26.9]
 [urllib3==1.26.10]
 [urllib3==1.26.11]
@@ -718,6 +779,8 @@ validate_incorrect_missing_deps = beautifulsoup4
 [virtualenv==20.14.1]
 [virtualenv==20.15.1]
 [virtualenv==20.16.3]
+
+[vultr==1.0.1]
 
 [watchdog==2.1.9]
 
@@ -756,6 +819,9 @@ brew_requires =
 
 [yarl==1.8.1]
 
+[zc-lockfile==2.0]
+
+[zipp==3.5.0]
 [zipp==3.8.1]
 
 [zstandard==0.18.0]


### PR DESCRIPTION
This is a better version, they've removed pyobjc as a dependency which was a problematic one: https://github.com/getsentry/pypi/pull/73

Also note that we're broken on `salt-ssh 3005 requires jinja2==3.1.0` but would be an easy fix (we should also freeze our deps):

```
  File "/Users/josh/dev/ops/k8s/cli/sentry_kube/ext.py", line 6, in <module>
    from jinja2 import contextfunction
ImportError: cannot import name 'contextfunction' from 'jinja2' (/Users/josh/dev/ops/.ops-venv/lib/python3.8/site-packages/jinja2/__init__.py)
```

Gonna be testing salt-ssh if it works for ops usage.

Oh yeah, also note that `dumpster` has python 3.7, we need Python 3.8.

Nice, can't even pip install this thing on Python 3.8.

```
        File "/private/var/folders/fn/y6rxl3jd28d3yq5j0_702bbc0000gn/T/pip-build-env-g1ig9m60/overlay/lib/python3.8/site-packages/setuptools/_distutils/core.py", line 147, in setup
          _setup_distribution = dist = klass(attrs)
        File "<string>", line 987, in __init__
        File "<string>", line 993, in update_metadata
        File "<string>", line 1124, in _property_install_requires
        File "<string>", line 179, in _parse_requirements_file
      FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/fn/y6rxl3jd28d3yq5j0_702bbc0000gn/T/pip-install-ws4cuc7m/salt-ssh_3c965dea925249d2b94df3072ee009ac/requirements/static/pkg/py3.8/darwin.txt'
```

lmao, well, just copied that darwin.txt over to py3.8 and works locally for `-r 'ls'` and `state.apply`.

```
joshua.li@thanks-again-tim-apple pkg * use-prebuilt-dependencies $ ls -plAhG py3.8
total 24
-rw-r--r--@ 1 josh  staff   2.4K Aug 25 08:07 freebsd.txt
-rw-r--r--@ 1 josh  staff   2.4K Aug 25 08:07 linux.txt
-rw-r--r--@ 1 josh  staff   3.2K Aug 25 08:07 windows.txt
joshua.li@thanks-again-tim-apple pkg * use-prebuilt-dependencies $ ls -plAhG py3.9
total 32
-rw-r--r--@ 1 josh  staff   2.7K Aug 25 08:07 darwin.txt
-rw-r--r--@ 1 josh  staff   2.4K Aug 25 08:07 freebsd.txt
-rw-r--r--@ 1 josh  staff   2.5K Aug 25 08:07 linux.txt
-rw-r--r--@ 1 josh  staff   3.2K Aug 25 08:07 windows.txt
```