### PR TITLE
add google-crc32c==1.5.0

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -220,6 +220,7 @@ validate_incorrect_missing_deps = six
 apt_requires = cmake
 brew_requires = cmake
 custom_prebuild = prebuild/crc32c 1.1.2
+[google-crc32c==1.5.0]
 
 [google-resumable-media==1.3.3]
 [google-resumable-media==2.3.3]


### PR DESCRIPTION
the latest version of this package comes with prebuilt wheels for the plat/arch pairs we care about so we no longer need special build instructions