### PR TITLE
improve new-user ergonomics

### DIFF
--- a/add_pkg.py
+++ b/add_pkg.py
@@ -8,7 +8,15 @@ import sys
 import tempfile
 from typing import Sequence
 
-from packaging.utils import parse_wheel_filename
+try:
+    from packaging.utils import parse_wheel_filename
+except ImportError:
+    raise SystemExit("""Dependencies not found. To continue, please run:
+
+    brew install tox
+    tox --devenv venv
+    . venv/bin/activate
+""")
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,3 +18,7 @@ warn_unused_ignores = true
 
 [mypy-tests.*]
 disallow_untyped_defs = false
+
+[options]
+package_dir =
+    sentry_pypi = .


### PR DESCRIPTION
old:
```
$ python3 -m add_pkg
Traceback (most recent call last):
  File "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/buck/repo/getsentry/pypi/add_pkg.py", line 11, in <module>
    from packaging.utils import parse_wheel_filename
ModuleNotFoundError: No module named 'packaging'
exit code: 1
```

new:

```
$ python3 -m add_pkg
Dependencies not found. To continue, please run:

    brew install tox
    tox --devenv venv
    . venv/bin/activate

exit code: 1
duration: 204.708 milliseconds
```