### PR TITLE
Add sentry-sdk==1.9.10

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -689,6 +689,7 @@ brew_requires = libyaml
 [sentry-sdk==1.9.5]
 [sentry-sdk==1.9.8]
 [sentry-sdk==1.9.9]
+[sentry-sdk==1.9.10]
 
 [setuptools==56.0.0]
 [setuptools==62.3.2]


### PR DESCRIPTION
sentry-sdk==1.9.9 had a bug with django signals (getsentry/sentry-python#1641) that is fixed in 1.9.10