### PR TITLE
fix --devenv by using more specific skip_install

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = py38
-skipsdist = true
 
 [testenv]
+skip_install = true
 deps =
     -rdocker/requirements.txt
     coverage


### PR DESCRIPTION
rather than fixing `--devenv` for `skipsdist` (which _sometimes_ implies `skip_install` but not in `usedevelop` mode for historical reasons I don't understand) -- moving to `skip_install` seems to work