### PR TITLE
Add sentry-relay 0.8.15

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -700,7 +700,6 @@ brew_requires = libyaml
 
 [sentry-relay==0.8.12]
 [sentry-relay==0.8.13]
-[sentry-relay==0.8.14]
 [sentry-relay==0.8.15]
 
 [sentry-sdk==1.6.0]

--- a/packages.ini
+++ b/packages.ini
@@ -701,6 +701,7 @@ brew_requires = libyaml
 [sentry-relay==0.8.12]
 [sentry-relay==0.8.13]
 [sentry-relay==0.8.14]
+[sentry-relay==0.8.15]
 
 [sentry-sdk==1.6.0]
 [sentry-sdk==1.9.0]


### PR DESCRIPTION
This also yanks 0.8.14 since it contained a regression in the normalize function.