### PR TITLE
add cryptography 38.0.3

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -130,6 +130,7 @@ custom_prebuild = prebuild/librdkafka v1.9.2
 [cryptography==37.0.2]
 [cryptography==37.0.4]
 [cryptography==38.0.1]
+[cryptography==38.0.3]
 
 [cssselect==1.0.3]
 [cssselect==1.1.0]


### PR DESCRIPTION
Adding `cryptography` version `38.0.3` to resolve OpenSSL vulnerabilities. See https://github.com/pyca/cryptography/security/advisories/GHSA-39hc-v87j-747x.