### PR TITLE
remove gcloud utils install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,5 +73,4 @@ jobs:
     - uses: google-github-actions/auth@v0
       with:
         credentials_json: ${{ secrets.PYPI_DEVINFRA_SENTRY_IO }}
-    - uses: google-github-actions/setup-gcloud@v0
     - run: python3 -uS bin/upload-artifacts


### PR DESCRIPTION
github includes these by default

Committed via https://github.com/asottile/all-repos