### PR TITLE
Add sentry-sdk==1.11.0

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -716,6 +716,7 @@ brew_requires = libyaml
 [sentry-sdk==1.9.9]
 [sentry-sdk==1.9.10]
 [sentry-sdk==1.10.1]
+[sentry-sdk==1.11.0]
 
 [setuptools==56.0.0]
 [setuptools==62.3.2]


### PR DESCRIPTION
This is now the min version for python profiling