### PR TITLE
fix gcloud auth by explicitly logging in

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,5 +73,5 @@ jobs:
     - uses: google-github-actions/auth@v0
       with:
         credentials_json: ${{ secrets.PYPI_DEVINFRA_SENTRY_IO }}
-    - uses: google-github-actions/setup-gcloud@v0
+    - run: yes | gcloud auth login --cred-file="$GOOGLE_APPLICATION_CREDENTIALS"
     - run: python3 -uS bin/upload-artifacts


### PR DESCRIPTION
apparently gsutil doesn't use `GOOGLE_APPLICATION_CREDENTIALS` unless explicitly logged in

tried this out on a test branch