### PR TITLE
ref(snuba-sdk) Allow the latest version of the Snuba SDK

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -785,6 +785,7 @@ python_versions = <3.11
 
 [snuba-sdk==1.0.0]
 [snuba-sdk==1.0.1]
+[snuba-sdk==1.0.2]
 
 [sortedcontainers==2.4.0]
 


### PR DESCRIPTION
This is dependent on https://github.com/getsentry/snuba-sdk/pull/106 being merged and released.