### PR TITLE
add typed-ast package

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -895,6 +895,8 @@ python_versions = <3.11
 
 [trio-websocket==0.9.2]
 
+[typed-ast==1.5.4]
+
 [types-beautifulsoup4==4.11.6]
 
 [types-freezegun==1.1.10]


### PR DESCRIPTION
```
pypi on  add-typed-ast [?] via 🐍 v3.11.1 (venv) on ☁️  michael@sentry.io(us-central1)
❯ python3 -m add_pkg 'typed-ast>=1.4.2'
resolving typed-ast>=1.4.2...
typed-ast==1.5.4: adding...
packages.ini: formatted
```