### PR TITLE
add latest pytest and pytest-rerunfailures

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -629,6 +629,7 @@ brew_requires =
 [pytest==7.1.2]
 [pytest==7.1.3]
 [pytest==7.2.0]
+[pytest==7.2.1]
 
 [pytest-cov==3.0.0]
 [pytest-cov==4.0.0]
@@ -644,6 +645,7 @@ brew_requires =
 
 [pytest-rerunfailures==9.1.1]
 [pytest-rerunfailures==10.2]
+[pytest-rerunfailures==11.0]
 
 [pytest-sentry==0.1.9]
 [pytest-sentry==0.1.10]


### PR DESCRIPTION
I think this fixes a hang I'm experiencing in pytest-xdist