### PR TITLE
add django lts 3.2.16

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -173,6 +173,7 @@ validate_incorrect_missing_deps = six
 [distro==1.8.0]
 
 [django==2.2.28]
+[django==3.2.16]
 [django==4.1]
 [django==4.1.1]
 [django==4.1.2]


### PR DESCRIPTION
Adds Django 3.2.16 to our package list.