### PR TITLE
Bump redis to 4.5.4

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -773,6 +773,7 @@ brew_requires = libyaml
 [redis==3.4.1]
 [redis==3.5.3]
 [redis==4.3.4]
+[redis==4.5.4]
 
 [redis-py-cluster==2.1.0]
 [redis-py-cluster==2.1.3]


### PR DESCRIPTION
Redis through 4.5.3 has two severe security issues which we're being alerted on. I'm adding the latest version in addition to the current one for transition.

See https://github.com/getsentry/relay/security/dependabot/55
See https://github.com/getsentry/relay/security/dependabot/56
