### PR TITLE
Keep json endpoints

### DIFF
--- a/make_index.py
+++ b/make_index.py
@@ -117,9 +117,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         )
 
-    # for now we don't utilize the json api
-    shutil.rmtree(os.path.join(args.dest, "pypi"), ignore_errors=True)
-
     return 0
 
 


### PR DESCRIPTION
I'm not sure what the best way to test this is. Running make_index doesn't produce any output, presumably because it doesn't have any packages built.