### PR TITLE
add django-csp 3.7

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -192,6 +192,8 @@ validate_incorrect_missing_deps = six
 
 [django-crispy-forms==1.14.0]
 
+[django-csp==3.7]
+
 [django-pg-zero-downtime-migrations==0.11]
 
 [django-stubs==1.12.0]
@@ -738,6 +740,7 @@ brew_requires =
 [pytz==2022.1]
 [pytz==2022.2]
 [pytz==2022.2.1]
+[pytz==2023.3]
 
 [pytz-deprecation-shim==0.1.0.post0]
 
@@ -987,6 +990,7 @@ validate_incorrect_missing_deps = beautifulsoup4
 [sqlparse==0.3.0]
 [sqlparse==0.4.2]
 [sqlparse==0.4.3]
+[sqlparse==0.4.4]
 
 [sshuttle==1.0.5]
 [sshuttle==1.1.1]


### PR DESCRIPTION
```
$ python3 -m add_pkg django-csp django==2.2.28
resolving django-csp django==2.2.28...

[notice] A new release of pip available: 22.3.1 -> 23.1.2
[notice] To update, run: python3.11 -m pip install --upgrade pip
django==2.2.28: already present!
django-csp==3.7: adding...
pytz==2023.3: adding...
sqlparse==0.4.4: adding...
packages.ini: formatted
```