### PR TITLE
chore(deps): Add covdefaults 2.3.0

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -147,6 +147,7 @@ custom_prebuild = prebuild/librdkafka v2.1.1
 [contextvars==2.4]
 
 [covdefaults==2.2.0]
+[covdefaults==2.3.0]
 
 [coverage==6.3.3]
 [coverage==6.4.1]
@@ -154,6 +155,7 @@ custom_prebuild = prebuild/librdkafka v2.1.1
 [coverage==6.4.4]
 [coverage==6.5.0]
 [coverage==7.1.0]
+[coverage==7.2.7]
 
 [croniter==0.3.37]
 [croniter==1.3.5]


### PR DESCRIPTION
This adds `covdefaults` version 2.3.0, [as suggested by @asottile-sentry](https://github.com/getsentry/sentry/pull/51654#discussion_r1242869671), in order to get the `if TYPE_CHECKING` coverage exclusion. It will be added to `requirements-dev.txt` in `sentry` in a follow-up PR.