### PR TITLE
feat: Add jsondiff

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -434,6 +434,8 @@ validate_extras = pytest
 [jmespath==0.10.0]
 [jmespath==1.0.1]
 
+[jsondiff==2.0.0]
+
 [jsonnet==0.20.0]
 
 [jsonschema==3.2.0]


### PR DESCRIPTION
This is a useful dev dependency for validating JSON imports and exports from self-hosted.