### PR TITLE
build: Build msgpack 1.0.4 for python 3.11

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -538,7 +538,6 @@ brew_requires = libmaxminddb
 [msgpack==1.0.2]
 python_versions = <3.11
 [msgpack==1.0.4]
-python_versions = <3.11
 
 [msgpack-types==0.2.0]
 


### PR DESCRIPTION
This failed before, so if this attempt fails we will instead add 1.0.5.