### PR TITLE
Add the gojsonnet binding

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -328,6 +328,8 @@ validate_incorrect_missing_deps = six
 
 [gitpython==3.1.12]
 
+[gojsonnet==0.20.0]
+
 [google-api-core==1.32.0]
 [google-api-core==2.8.2]
 [google-api-core==2.10.1]


### PR DESCRIPTION
gojsonnet is the python binding for the Go implementation of the jsonnet parser. 
The Go implementation is meant to become the reference implementation.