### PR TITLE
chore(relay): Add new version manually

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -112,6 +112,9 @@ brew_requires = libffi
 [cffi==1.15.1]
 apt_requires = libffi-dev
 brew_requires = libffi
+[cffi==1.16.0]
+apt_requires = libffi-dev
+brew_requires = libffi
 
 [cfgv==3.3.1]
 [cfgv==3.4.0]
@@ -1145,6 +1148,7 @@ python_versions = <3.11
 [sentry-relay==0.8.29]
 [sentry-relay==0.8.30]
 [sentry-relay==0.8.31]
+[sentry-relay==0.8.32]
 
 [sentry-sdk==1.6.0]
 [sentry-sdk==1.9.0]


### PR DESCRIPTION
The automated publishing job succeeded in publishing to public pypi [but not our own](https://github.com/getsentry/publish/actions/runs/6456042703/job/17524719367#step:10:679), so subsequent runs would fail because the package is already present on pypi.org.

Manually add `sentry-relay==0.8.32` so it becomes available to clients of our local pypi.