### PR TITLE
Update milksnake == 0.1.6

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -581,6 +581,7 @@ brew_requires = libmaxminddb
 [mdurl==0.1.2]
 
 [milksnake==0.1.5]
+[milksnake==0.1.6]
 
 [mistune==2.0.4]
 [mistune==3.0.1]


### PR DESCRIPTION
Newest milksnake, needed as a dependency for relay.

See https://github.com/getsentry/pypi/actions/runs/6667534528/job/18121888552?pr=478#step:5:9.