### PR TITLE
add codecov-cli and deps

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -15,6 +15,7 @@ python_versions = <3.11
 [amqp==5.1.1]
 
 [anyio==3.6.1]
+[anyio==4.0.0]
 
 [asgiref==3.5.2]
 [asgiref==3.6.0]
@@ -145,6 +146,8 @@ brew_requires = libffi
 
 [clickhouse-driver==0.2.4]
 python_versions = <3.11
+
+[codecov-cli==0.4.1]
 
 [colorama==0.4.5]
 
@@ -449,11 +452,13 @@ python_versions = <3.11
 
 [httpcore==0.11.1]
 [httpcore==0.15.0]
+[httpcore==0.16.3]
 
 [httplib2==0.22.0]
 
 [httpx==0.15.4]
 [httpx==0.23.0]
+[httpx==0.23.3]
 
 [hypothesis==6.61.0]
 validate_extras = pytest
@@ -469,6 +474,8 @@ validate_extras = pytest
 [idna==2.10]
 [idna==3.3]
 [idna==3.4]
+
+[ijson==3.2.3]
 
 [imagesize==1.4.1]
 
@@ -1267,6 +1274,8 @@ python_versions = <3.11
 
 [six==1.16.0]
 
+[smart-open==6.4.0]
+
 [smmap==3.0.2]
 
 [sniffio==1.2.0]
@@ -1380,6 +1389,8 @@ python_versions = <3.11
 
 [tqdm==4.64.1]
 [tqdm==4.65.0]
+
+[tree-sitter==0.20.2]
 
 [trio==0.21.0]
 [trio==0.22.2]


### PR DESCRIPTION
These changes were made by following the exact instructions on Readme.md, that is, running `python3 -m add_pkg codecov-cli`.

This is used in the `codecov-ats.yml` workflow and currently requires the extra index to Pypi to be installed.
See: https://github.com/getsentry/sentry/blob/d069119cee5dfc887cf3f0744e4c8ebdf9be8a9c/.github/workflows/codecov_ats.yml#L76C100-L76C100