### PR TITLE
enable clickhouse-driver in 3.11+

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -149,6 +149,7 @@ brew_requires = libffi
 
 [clickhouse-driver==0.2.4]
 python_versions = <3.11
+[clickhouse-driver==0.2.6]
 
 [colorama==0.4.5]
 


### PR DESCRIPTION
this is buildable / downloadable now