### PR TITLE
add newer versions of stripe

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -112,6 +112,7 @@ validate_extras = d
 [certifi==2022.12.7]
 [certifi==2023.5.7]
 [certifi==2023.7.22]
+[certifi==2023.11.17]
 
 [cffi==1.14.6]
 apt_requires = libffi-dev
@@ -483,6 +484,7 @@ validate_extras = pytest
 [idna==2.10]
 [idna==3.3]
 [idna==3.4]
+[idna==3.6]
 
 [imagesize==1.4.1]
 
@@ -1378,7 +1380,13 @@ validate_incorrect_missing_deps = beautifulsoup4
 [statsd==3.3.0]
 
 [stripe==2.61.0]
+[stripe==3.1.0]
+[stripe==3.5.0]
 [stripe==4.1.0]
+[stripe==4.2.0]
+[stripe==5.5.0]
+[stripe==6.7.0]
+[stripe==7.6.0]
 
 [structlog==21.1.0]
 [structlog==22.1.0]
@@ -1590,6 +1598,7 @@ python_versions = <3.11
 [urllib3==2.0.4]
 [urllib3==2.0.6]
 [urllib3==2.0.7]
+[urllib3==2.1.0]
 
 [vine==1.3.0]
 [vine==5.0.0]


### PR DESCRIPTION
the old version of stripe vendors a copy of `six` which does not import in python 3.10