### PR TITLE
add newer datadog client

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -217,6 +217,8 @@ custom_prebuild = prebuild/librdkafka v2.1.1
 [datadog==0.21.0]
 [datadog==0.29.3]
 [datadog==0.31.0]
+[datadog==0.35.0]
+[datadog==0.39.0]
 [datadog==0.44.0]
 [datadog==0.46.0]
 


### PR DESCRIPTION
trying to pin down the breakage between the current version and 0.46 by trying a few intermediate versions