### PR TITLE
ref: add pymemcache as a potential replacement for python-memcached

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -887,6 +887,8 @@ brew_requires =
 
 [pyjwt==2.4.0]
 
+[pymemcache==4.0.0]
+
 [pynacl==1.5.0]
 
 [pyopenssl==22.0.0]


### PR DESCRIPTION
`python-memcached` is dead -- this seems like the most active alternative