### PR TITLE
upgrade pip to latest

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -770,6 +770,7 @@ python_versions = <3.11
 [pip==23.0.1]
 [pip==23.1.2]
 [pip==23.2.1]
+[pip==23.3.1]
 
 [pip-tools==6.7.0]
 [pip-tools==6.8.0]


### PR DESCRIPTION
I'm hoping this unbreaks new-setuptools-building-git-archives in `getsentry` on python 3.10+