### PR TITLE
add latest setuptools-scm

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -1399,10 +1399,12 @@ python_versions = <3.11
 [setuptools==67.8.0]
 [setuptools==68.0.0]
 [setuptools==68.2.2]
+[setuptools==69.0.2]
 
 [setuptools-rust==1.5.2]
 
 [setuptools-scm==7.0.5]
+[setuptools-scm==8.0.4]
 
 [simplejson==3.17.2]
 [simplejson==3.17.6]
@@ -1667,6 +1669,7 @@ python_versions = <3.11
 [typing-extensions==4.7.0]
 [typing-extensions==4.7.1]
 [typing-extensions==4.8.0]
+[typing-extensions==4.9.0]
 
 [typing-inspect==0.7.1]
 [typing-inspect==0.8.0]


### PR DESCRIPTION
this is needed to build newer versions of lazy-object-proxy