### PR TITLE
chore(linting): update flake8-logging to 1.5.0 to include a fix

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -361,6 +361,7 @@ validate_incorrect_missing_deps = six
 [flake8==5.0.4]
 [flake8==6.0.0]
 [flake8==6.1.0]
+[flake8==7.0.0]
 
 [flake8-bugbear==22.7.1]
 [flake8-bugbear==22.8.23]
@@ -373,6 +374,7 @@ validate_incorrect_missing_deps = six
 [flake8-bugbear==23.12.2]
 
 [flake8-logging==1.4.0]
+[flake8-logging==1.5.0]
 
 [flask==2.1.2]
 [flask==2.2.2]
@@ -925,6 +927,7 @@ brew_requires =
 [pyflakes==2.5.0]
 [pyflakes==3.0.1]
 [pyflakes==3.1.0]
+[pyflakes==3.2.0]
 
 [pygments==2.13.0]
 


### PR DESCRIPTION
Bumping flake8-logging to 1.5.0 to include fix for 
```python
KeyError "Attempt to overwrite 'message' in LogRecord"
```

Changelog: https://github.com/adamchainz/flake8-logging/blob/main/CHANGELOG.rst#150-2024-01-23
Fix: https://github.com/adamchainz/flake8-logging/pull/77
