### PR TITLE
add latest versions of django and pre-commit

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -275,6 +275,7 @@ validate_incorrect_missing_deps = six
 [django==4.2.6]
 [django==4.2.7]
 [django==4.2.8]
+[django==5.0.1]
 
 [django-crispy-forms==1.14.0]
 
@@ -836,6 +837,7 @@ python_versions = <3.11
 [platformdirs==3.10.0]
 [platformdirs==4.0.0]
 [platformdirs==4.1.0]
+[platformdirs==4.2.0]
 
 [pluggy==0.13.1]
 [pluggy==1.0.0]
@@ -847,6 +849,7 @@ python_versions = <3.11
 [pre-commit==3.0.4]
 [pre-commit==3.3.2]
 [pre-commit==3.4.0]
+[pre-commit==3.6.0]
 
 [progressbar2==3.41.0]
 [progressbar2==4.0.0]
@@ -1470,6 +1473,7 @@ python_versions = >=3.10
 [setuptools==68.0.0]
 [setuptools==68.2.2]
 [setuptools==69.0.2]
+[setuptools==69.0.3]
 
 [setuptools-rust==1.5.2]
 


### PR DESCRIPTION
these were previously held back due to requiring pypi packages to support 3.8