### PR TITLE
feat: likely_binary_ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ source files:
 ```ini
 [salt==3006.6]
 likely_binary_ignore =
-    pkg/smartos/esky/sodium_grabber.c
+    salt-3006.6/pkg/old/smartos/esky/sodium_grabber.c
 ```
 
 ### python_versions

--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ the script should set up whatever tools are necessary inside only that directory
 custom_prebuild = prebuild/crc32c 1.1.2
 ```
 
+### likely_binary_ignore
+
+when the sdist has source files of a compiled language (see BINARY_EXTS),
+we would expect compiled things (e.g. binary executables, shared objects)
+in the wheel. sometimes this isn't the case, and you can ignore those
+source files:
+
+
+```ini
+[salt==3006.6]
+likely_binary_ignore =
+    pkg/smartos/esky/sodium_grabber.c
+```
+
 ### python_versions
 
 some packages are only intended for particular python versions (or don't
@@ -73,6 +87,7 @@ otherwise build cleanly).  the builds can be filtered using `python_versions`
 [backports-zoneinfo==0.2.1]
 python_versions = <3.9
 ```
+
 
 ## validation
 

--- a/build.py
+++ b/build.py
@@ -500,7 +500,7 @@ def _prebuild(
             env.update(before)
 
 
-def _likely_binary(sdist: str, likely_binary_ignore: tuple[str, ...]]) -> str | None:
+def _likely_binary(sdist: str, likely_binary_ignore: tuple[str, ...]) -> str | None:
     if sdist.endswith(".zip"):
         with zipfile.ZipFile(sdist) as zipf:
             names = zipf.namelist()
@@ -528,8 +528,7 @@ def _likely_binary(sdist: str, likely_binary_ignore: tuple[str, ...]]) -> str | 
         if "/test/" in name or "/tests/" in name:
             continue
 
-        print(name)
-        if name in package.likely_binary_ignore:
+        if name in likely_binary_ignore:
             continue
 
         _, ext = os.path.splitext(name)

--- a/build.py
+++ b/build.py
@@ -71,6 +71,7 @@ class Package(NamedTuple):
     apt_requires: tuple[str, ...]
     brew_requires: tuple[str, ...]
     custom_prebuild: tuple[str, ...]
+    likely_binary_ignore: tuple[str, ...]
     python_versions: SpecifierSet
 
     def satisfied_by(
@@ -92,6 +93,7 @@ class Package(NamedTuple):
         apt_requires = tuple(dct.pop("apt_requires", "").split())
         brew_requires = tuple(dct.pop("brew_requires", "").split())
         custom_prebuild = tuple(dct.pop("custom_prebuild", "").split())
+        likely_binary_ignore = tuple(dct.pop("likely_binary_ignore", "").split())
         python_versions = dct.pop("python_versions", "")
         # ignore validate-only settings
         for setting in (
@@ -109,6 +111,7 @@ class Package(NamedTuple):
             apt_requires=apt_requires,
             brew_requires=brew_requires,
             custom_prebuild=custom_prebuild,
+            likely_binary_ignore=likely_binary_ignore,
             python_versions=SpecifierSet(python_versions),
         )
 
@@ -497,7 +500,7 @@ def _prebuild(
             env.update(before)
 
 
-def _likely_binary(sdist: str) -> str | None:
+def _likely_binary(sdist: str, likely_binary_ignore: tuple[str, ...]]) -> str | None:
     if sdist.endswith(".zip"):
         with zipfile.ZipFile(sdist) as zipf:
             names = zipf.namelist()
@@ -523,6 +526,10 @@ def _likely_binary(sdist: str) -> str | None:
     ret = set()
     for name in names:
         if "/test/" in name or "/tests/" in name:
+            continue
+
+        print(name)
+        if name in package.likely_binary_ignore:
             continue
 
         _, ext = os.path.splitext(name)
@@ -587,7 +594,7 @@ def _build(package: Package, python: Python, dest: str, index_url: str) -> str:
             (filename,) = os.listdir(build_dir)
             filename_full = os.path.join(build_dir, filename)
 
-            likely_binary_reason = _likely_binary(sdist)
+            likely_binary_reason = _likely_binary(sdist, package.likely_binary_ignore)
             if likely_binary_reason and not _produced_binary(filename_full):
                 raise SystemExit(
                     f"{package.name}=={package.version} expected binary as "


### PR DESCRIPTION
required for https://github.com/getsentry/pypi/pull/643 (which has this branch included for salt build to succeed), redo of #76 