### PR TITLE
add slipcover

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -1561,6 +1561,8 @@ python_versions = >=3.10
 
 [six==1.16.0]
 
+[slipcover==1.0.3]
+
 [smmap==3.0.2]
 [smmap==4.0.0]
 
@@ -1683,6 +1685,7 @@ python_versions = <3.12
 
 [tabulate==0.8.9]
 [tabulate==0.8.10]
+[tabulate==0.9.0]
 
 [time-machine==2.12.0]
 [time-machine==2.13.0]


### PR DESCRIPTION
slipcover is an alternative coverage tool that aims to be faster.  I'd like to see the impact on sentry's test times