### PR TITLE
add latest djangorestframework

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -28,6 +28,7 @@ python_versions = <3.12
 [asgiref==3.6.0]
 [asgiref==3.7.2]
 [asgiref==3.8.0]
+[asgiref==3.8.1]
 
 [async-generator==1.10]
 
@@ -317,6 +318,7 @@ validate_incorrect_missing_deps = six
 [djangorestframework==3.12.4]
 [djangorestframework==3.13.1]
 [djangorestframework==3.14.0]
+[djangorestframework==3.15.1]
 
 [djangorestframework-stubs==3.14.0]
 [djangorestframework-stubs==3.14.2]


### PR DESCRIPTION
this should finally allow us to purge `pytz`