### PR TITLE
add the latest version of kombu

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -642,6 +642,7 @@ python_versions = <3.12
 [kombu==5.2.4]
 [kombu==5.3.3]
 [kombu==5.3.4]
+[kombu==5.3.6]
 
 [kubernetes==19.15.0]
 [kubernetes==24.2.0]


### PR DESCRIPTION
this fixes a noisy warning in python 3.12