### PR TITLE
chore: add orjson v3.10.0

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -827,6 +827,8 @@ python_versions = <3.12
 
 [opentelemetry-proto==1.22.0]
 
+[orjson==3.10.0]
+
 [outcome==1.2.0]
 [outcome==1.3.0.post0]
 


### PR DESCRIPTION
https://python-rapidjson.readthedocs.io/en/latest/benchmarks.html

I don't see any reason to use `rapidjson` after the benchmarks.

Ref: https://github.com/getsentry/team-processing/issues/145