### PR TITLE
sql-metadata 2.11.0

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -1740,6 +1740,7 @@ validate_incorrect_missing_deps = beautifulsoup4
 [sphinxcontrib-serializinghtml==1.1.5]
 
 [sql-metadata==2.6.0]
+[sql-metadata==2.11.0]
 
 [sqlalchemy==1.4.41]
 python_versions = <3.12


### PR DESCRIPTION
Additional necessary dependency update for https://github.com/getsentry/pypi/pull/769. 

```
The conflict is caused by:
     The user requested sqlparse==0.5.0
     sql-metadata 2.6.0 depends on sqlparse<0.5.0 and >=0.4.1
```