### PR TITLE
macos-latest -> macos-13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
   macos:
     strategy:
       matrix:
-        runs-on: [macos-14, macos-latest]
+        runs-on: [macos-14, macos-13]
     runs-on: ${{ matrix.runs-on }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
github silently changed the architecture of macos-latest from intel to arm64