### PR TITLE
Add tldextract package

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -141,6 +141,7 @@ validate_extras = d
 [certifi==2023.7.22]
 [certifi==2023.11.17]
 [certifi==2024.2.2]
+[certifi==2024.6.2]
 
 [cffi==1.14.6]
 apt_requires = libffi-dev
@@ -396,6 +397,7 @@ validate_incorrect_missing_deps = six
 [filelock==3.12.1]
 [filelock==3.12.4]
 [filelock==3.13.1]
+[filelock==3.15.3]
 
 [flake8==4.0.1]
 [flake8==5.0.2]
@@ -1262,6 +1264,9 @@ python_versions = <3.12
 [requests==2.30.0]
 [requests==2.31.0]
 [requests==2.32.2]
+[requests==2.32.3]
+
+[requests-file==2.1.0]
 
 [requests-oauthlib==1.2.0]
 [requests-oauthlib==1.3.1]
@@ -1923,6 +1928,8 @@ python_versions = <3.12
 
 [timelib==0.2.5]
 python_versions = <3.11
+
+[tldextract==5.1.2]
 
 [tokenize-rt==4.2.1]
 [tokenize-rt==5.0.0]


### PR DESCRIPTION
I'm looking to use this as part of a project I'm working on. It's a bit of a pain that it installs `requests` - I think it only uses that to download a new list from the public suffix list, which I will be disabling, so we don't really even need it.