### PR TITLE
add latest version of deps to resolve dependabot alerts

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -83,6 +83,8 @@ validate_extras = d
 validate_extras = d
 [black==24.3.0]
 validate_extras = d
+[black==24.4.2]
+validate_extras = d
 
 [blinker==1.4]
 [blinker==1.5]
@@ -142,6 +144,7 @@ validate_extras = d
 [certifi==2023.11.17]
 [certifi==2024.2.2]
 [certifi==2024.6.2]
+[certifi==2024.7.4]
 
 [cffi==1.14.6]
 apt_requires = libffi-dev
@@ -308,6 +311,7 @@ validate_incorrect_missing_deps = six
 [django==5.0.3]
 [django==5.0.4]
 [django==5.0.6]
+[django==5.0.7]
 
 [django-crispy-forms==1.14.0]
 
@@ -340,6 +344,7 @@ validate_incorrect_missing_deps = six
 [djangorestframework==3.13.1]
 [djangorestframework==3.14.0]
 [djangorestframework==3.15.1]
+[djangorestframework==3.15.2]
 
 [djangorestframework-stubs==3.14.0]
 [djangorestframework-stubs==3.14.2]
@@ -870,6 +875,7 @@ python_versions = <3.12
 [packaging==23.1]
 [packaging==23.2]
 [packaging==24.0]
+[packaging==24.1]
 
 [paramiko==2.11.0]
 
@@ -917,6 +923,7 @@ python_versions = <3.12
 [pillow==10.1.0]
 [pillow==10.2.0]
 [pillow==10.3.0]
+[pillow==10.4.0]
 
 [pip==22.1.2]
 [pip==22.2.2]
@@ -949,6 +956,7 @@ python_versions = <3.12
 [platformdirs==4.0.0]
 [platformdirs==4.1.0]
 [platformdirs==4.2.0]
+[platformdirs==4.2.2]
 
 [pluggy==0.13.1]
 [pluggy==1.0.0]
@@ -1790,6 +1798,7 @@ python_versions = >=3.10
 [setuptools==68.2.2]
 [setuptools==69.0.2]
 [setuptools==69.0.3]
+[setuptools==70.0.0]
 
 [setuptools-rust==1.5.2]
 
@@ -1886,6 +1895,7 @@ python_versions = <3.12
 [sqlparse==0.4.3]
 [sqlparse==0.4.4]
 [sqlparse==0.5.0]
+[sqlparse==0.5.1]
 
 [sshuttle==1.0.5]
 [sshuttle==1.1.1]
@@ -1969,6 +1979,7 @@ python_versions = <3.11
 [tqdm==4.64.1]
 [tqdm==4.65.0]
 [tqdm==4.66.1]
+[tqdm==4.66.4]
 
 [trio==0.21.0]
 [trio==0.22.2]


### PR DESCRIPTION
We've got a good sized list of Dependabot alerts on getsentry/sentry. Adding these deps so that Dependabot can open PRs and get them resolved.