### PR TITLE
Add first release for sentry-protos

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -560,6 +560,8 @@ python_versions = <3.12
 
 [grpc-interceptor==0.15.4]
 
+[grpc-stubs==1.53.0.5]
+
 [grpcio==1.46.3]
 python_versions = <3.11
 [grpcio==1.47.0]
@@ -575,6 +577,7 @@ python_versions = <3.12
 [grpcio==1.60.1]
 [grpcio==1.62.1]
 [grpcio==1.64.0]
+[grpcio==1.65.4]
 
 [grpcio-status==1.47.0]
 [grpcio-status==1.48.1]
@@ -1659,6 +1662,8 @@ python_versions = >=3.10
 [sentry-ophio==0.2.5]
 [sentry-ophio==0.2.6]
 [sentry-ophio==0.2.7]
+
+[sentry-protos==0.1.3]
 
 [sentry-redis-tools==0.1.1]
 [sentry-redis-tools==0.1.2]


### PR DESCRIPTION
This will be automated with craft in the future. I've gotten this release published to pypy.org.