### PR TITLE
add latest google-cloud-spanner

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -119,6 +119,7 @@ validate_extras = d
 [cachetools==5.3.1]
 [cachetools==5.3.2]
 [cachetools==5.3.3]
+[cachetools==5.5.0]
 
 [celery==4.4.7]
 [celery==5.0.2]
@@ -145,6 +146,7 @@ validate_extras = d
 [certifi==2024.2.2]
 [certifi==2024.6.2]
 [certifi==2024.7.4]
+[certifi==2024.8.30]
 
 [cffi==1.14.6]
 apt_requires = libffi-dev
@@ -467,6 +469,7 @@ brew_requires = go
 [google-api-core==2.17.1]
 [google-api-core==2.19.0]
 [google-api-core==2.19.1]
+[google-api-core==2.19.2]
 
 [google-api-python-client==2.88.0]
 
@@ -483,6 +486,7 @@ brew_requires = go
 [google-auth==2.27.0]
 [google-auth==2.28.2]
 [google-auth==2.29.0]
+[google-auth==2.34.0]
 
 [google-auth-httplib2==0.1.0]
 
@@ -523,6 +527,7 @@ brew_requires = go
 [google-cloud-spanner==3.43.0]
 [google-cloud-spanner==3.46.0]
 [google-cloud-spanner==3.48.0]
+[google-cloud-spanner==3.49.0]
 
 [google-cloud-storage==1.35.0]
 [google-cloud-storage==2.5.0]
@@ -555,6 +560,7 @@ custom_prebuild = prebuild/crc32c 1.1.2
 [googleapis-common-protos==1.62.0]
 [googleapis-common-protos==1.63.0]
 [googleapis-common-protos==1.63.2]
+[googleapis-common-protos==1.65.0]
 
 [greenlet==1.1.3]
 python_versions = <3.12
@@ -584,6 +590,7 @@ python_versions = <3.12
 [grpcio==1.62.1]
 [grpcio==1.64.0]
 [grpcio==1.65.4]
+[grpcio==1.66.1]
 
 [grpcio-status==1.47.0]
 [grpcio-status==1.48.1]
@@ -594,6 +601,7 @@ python_versions = <3.12
 [grpcio-status==1.60.1]
 [grpcio-status==1.62.1]
 [grpcio-status==1.62.2]
+[grpcio-status==1.66.1]
 
 [h11==0.9.0]
 [h11==0.12.0]
@@ -638,6 +646,7 @@ validate_extras = pytest
 [idna==3.4]
 [idna==3.6]
 [idna==3.7]
+[idna==3.8]
 
 [imagesize==1.4.1]
 
@@ -1026,6 +1035,7 @@ python_versions = <3.12
 [protobuf==4.25.2]
 [protobuf==4.25.3]
 [protobuf==5.27.3]
+[protobuf==5.28.0]
 
 [psutil==5.8.0]
 [psutil==5.9.2]


### PR DESCRIPTION
this latest version has fewer unnecessary runtime deps: https://github.com/googleapis/python-spanner/pull/1158