### PR TITLE
add intermediate versions of pytest

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -1134,7 +1134,10 @@ brew_requires = libmemcached
 [pytest==7.2.1]
 [pytest==7.4.3]
 [pytest==8.0.0]
+[pytest==8.0.2]
 [pytest==8.1.1]
+[pytest==8.1.2]
+[pytest==8.2.2]
 [pytest==8.3.2]
 
 [pytest-cov==3.0.0]


### PR DESCRIPTION
something between pytest 8.0.0 and 8.3.2 is causing issues in sentry -- going to try and bump through the intermediates to hopefully pinpoint the regression