### PR TITLE
fix(sentry-infra-tools): Use existing dependencies

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -59,6 +59,7 @@ python_versions = <3.12
 python_versions = <3.9
 
 [bcrypt==4.0.0]
+[bcrypt==4.1.3]
 [bcrypt==4.2.0]
 
 [beautifulsoup4==4.7.1]
@@ -122,6 +123,7 @@ validate_extras = d
 [cachetools==5.3.1]
 [cachetools==5.3.2]
 [cachetools==5.3.3]
+[cachetools==5.4.0]
 [cachetools==5.5.0]
 
 [celery==4.4.7]
@@ -250,6 +252,7 @@ custom_prebuild = prebuild/librdkafka v2.3.0
 [cryptography==41.0.3]
 [cryptography==41.0.7]
 [cryptography==42.0.4]
+[cryptography==42.0.8]
 [cryptography==43.0.1]
 
 [cssselect==1.0.3]
@@ -483,6 +486,7 @@ brew_requires = go
 [google-api-core==2.19.2]
 
 [google-api-python-client==2.88.0]
+[google-api-python-client==2.137.0]
 [google-api-python-client==2.145.0]
 
 [google-auth==1.29.0]
@@ -498,6 +502,7 @@ brew_requires = go
 [google-auth==2.27.0]
 [google-auth==2.28.2]
 [google-auth==2.29.0]
+[google-auth==2.32.0]
 [google-auth==2.34.0]
 
 [google-auth-httplib2==0.1.0]
@@ -641,6 +646,7 @@ python_versions = <3.12
 [httpx==0.15.4]
 [httpx==0.23.0]
 [httpx==0.25.2]
+[httpx==0.27.0]
 [httpx==0.27.2]
 
 [hypothesis==6.61.0]
@@ -748,6 +754,7 @@ python_versions = <3.12
 [kubernetes==27.2.0]
 [kubernetes==30.1.0]
 
+[lark==1.1.9]
 [lark==1.2.2]
 
 [lark-parser==0.10.1]
@@ -852,6 +859,7 @@ python_versions = <3.11
 [msgpack==1.0.4]
 python_versions = <3.12
 [msgpack==1.0.7]
+[msgpack==1.0.8]
 [msgpack==1.1.0]
 
 [msgpack-types==0.2.0]
@@ -940,6 +948,7 @@ python_versions = <3.12
 [packaging==24.1]
 
 [paramiko==2.11.0]
+[paramiko==3.4.0]
 [paramiko==3.4.1]
 
 [parse==1.19.0]
@@ -1064,6 +1073,7 @@ python_versions = <3.12
 [protobuf==4.25.1]
 [protobuf==4.25.2]
 [protobuf==4.25.3]
+[protobuf==5.27.2]
 [protobuf==5.27.3]
 [protobuf==5.28.0]
 
@@ -1162,6 +1172,7 @@ brew_requires = libmemcached
 [pyopenssl==23.2.0]
 
 [pyparsing==3.0.9]
+[pyparsing==3.1.2]
 [pyparsing==3.1.4]
 
 [pyproject-hooks==1.0.0]
@@ -1245,6 +1256,7 @@ brew_requires = libmemcached
 
 [python-hcl2==2.0.3]
 [python-hcl2==3.0.5]
+[python-hcl2==4.3.4]
 [python-hcl2==4.3.5]
 
 [python-jose==3.3.0]


### PR DESCRIPTION
Since I am porting over the sentry-infra-tools from the ops repo, I would like to ensure that I do not inadvertently break the tooling. In order to do that I would like to use the same dependencies which exist in the ops repo instead of using their latest versions.

Once we verify everything works correctly, we can think of upgrading the package versions.