### PR TITLE
feat(ops): Add packages part of ops repo

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -519,6 +519,8 @@ brew_requires = go
 [google-cloud-build==3.22.0]
 [google-cloud-build==3.24.2]
 
+[google-cloud-compute==1.19.2]
+
 [google-cloud-core==1.5.0]
 [google-cloud-core==2.3.2]
 [google-cloud-core==2.4.1]
@@ -531,6 +533,8 @@ brew_requires = go
 [google-cloud-kms==2.19.1]
 [google-cloud-kms==2.20.0]
 [google-cloud-kms==2.24.2]
+
+[google-cloud-os-login==2.14.6]
 
 [google-cloud-pubsub==2.2.0]
 [google-cloud-pubsub==2.13.6]
@@ -807,6 +811,7 @@ brew_requires =
 [markdown==3.4.1]
 
 [markdown-it-py==2.1.0]
+[markdown-it-py==3.0.0]
 
 [markupsafe==2.0.1]
 [markupsafe==2.1.1]
@@ -1078,6 +1083,7 @@ python_versions = <3.12
 [protobuf==5.27.2]
 [protobuf==5.27.3]
 [protobuf==5.28.0]
+[protobuf==5.28.1]
 
 [psutil==5.8.0]
 [psutil==5.9.2]
@@ -1158,6 +1164,7 @@ brew_requires =
 [pyflakes==3.2.0]
 
 [pygments==2.13.0]
+[pygments==2.18.0]
 
 [pyjwt==2.4.0]
 
@@ -1400,6 +1407,8 @@ python_versions = <3.12
 [rfc3986==1.5.0]
 
 [rfc3986-validator==0.1.1]
+
+[rich==13.8.1]
 
 [rpds-py==0.9.2]
 [rpds-py==0.13.1]
@@ -2340,6 +2349,7 @@ python_versions = <3.11
 [urllib3==2.2.0]
 [urllib3==2.2.1]
 [urllib3==2.2.2]
+[urllib3==2.2.3]
 
 [vine==1.3.0]
 [vine==5.0.0]


### PR DESCRIPTION
This PR adds the packages which are needed by the ops repo but are not part of sentry infra tools. Adding these so that the venv created in ops repo can also use sentry pypi. These are basically the list from [here](https://github.com/getsentry/ops/blob/master/k8s/cli/requirements.in#L35-L47) 