### PR TITLE
add latest version of pre-commit

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -430,6 +430,7 @@ validate_incorrect_missing_deps = six
 [filelock==3.12.4]
 [filelock==3.13.1]
 [filelock==3.15.3]
+[filelock==3.16.1]
 
 [flake8==4.0.1]
 [flake8==5.0.2]
@@ -671,6 +672,7 @@ validate_extras = pytest
 [identify==2.5.24]
 [identify==2.5.29]
 [identify==2.5.33]
+[identify==2.6.1]
 
 [idna==2.8]
 [idna==2.10]
@@ -913,6 +915,7 @@ python_versions = <3.12
 [nodeenv==1.6.0]
 [nodeenv==1.7.0]
 [nodeenv==1.8.0]
+[nodeenv==1.9.1]
 
 [oauthlib==3.1.0]
 [oauthlib==3.2.0]
@@ -1042,6 +1045,7 @@ python_versions = <3.12
 [platformdirs==4.1.0]
 [platformdirs==4.2.0]
 [platformdirs==4.2.2]
+[platformdirs==4.3.6]
 
 [pluggy==0.13.1]
 [pluggy==1.0.0]
@@ -1057,6 +1061,7 @@ python_versions = <3.12
 [pre-commit==3.3.2]
 [pre-commit==3.4.0]
 [pre-commit==3.6.0]
+[pre-commit==4.0.0]
 
 [progressbar2==3.41.0]
 [progressbar2==4.0.0]
@@ -2398,6 +2403,7 @@ python_versions = <3.11
 [virtualenv==20.24.5]
 [virtualenv==20.24.7]
 [virtualenv==20.25.0]
+[virtualenv==20.26.6]
 
 [watchdog==2.1.9]
 python_versions = <3.12


### PR DESCRIPTION
also pulls in newer `nodeenv` which removes a dependence on deprecated `pkg_resources`