### PR TITLE
enable builds for python 3.13

### DIFF
--- a/build.py
+++ b/build.py
@@ -32,7 +32,7 @@ from packaging.tags import Tag
 from packaging.utils import parse_wheel_filename
 from packaging.version import Version
 
-PYTHONS = ((3, 11), (3, 12))
+PYTHONS = ((3, 11), (3, 12), (3, 13))
 
 BINARY_EXTS = frozenset(
     (".c", ".cc", ".cpp", ".cxx", ".pxd", ".pxi", ".pyx", ".go", ".rs")

--- a/packages.ini
+++ b/packages.ini
@@ -7,7 +7,9 @@ python_versions = <3.12
 [aiohttp==3.8.5]
 python_versions = <3.12
 [aiohttp==3.9.1]
+python_versions = <3.13
 [aiohttp==3.10.2]
+python_versions = <3.13
 [aiohttp==3.10.10]
 
 [aiosignal==1.2.0]
@@ -112,6 +114,8 @@ validate_extras = d
 [botocore==1.34.128]
 
 [brotli==1.0.9]
+python_versions = <3.12
+[brotli==1.1.0]
 
 [build==0.8.0]
 [build==0.10.0]
@@ -157,12 +161,15 @@ validate_extras = d
 [cffi==1.14.6]
 apt_requires = libffi-dev
 brew_requires = libffi
+python_versions = <3.13
 [cffi==1.15.1]
 apt_requires = libffi-dev
 brew_requires = libffi
+python_versions = <3.13
 [cffi==1.16.0]
 apt_requires = libffi-dev
 brew_requires = libffi
+python_versions = <3.13
 [cffi==1.17.1]
 apt_requires = libffi-dev
 brew_requires = libffi
@@ -178,10 +185,15 @@ brew_requires = libffi
 [charset-normalizer==2.1.0]
 [charset-normalizer==2.1.1]
 [charset-normalizer==3.0.1]
+python_versions = <3.13
 [charset-normalizer==3.1.0]
+python_versions = <3.13
 [charset-normalizer==3.2.0]
+python_versions = <3.13
 [charset-normalizer==3.3.0]
+python_versions = <3.13
 [charset-normalizer==3.3.2]
+python_versions = <3.13
 [charset-normalizer==3.4.0]
 
 [click==7.1.2]
@@ -198,6 +210,7 @@ brew_requires = libffi
 [click-repl==0.3.0]
 
 [clickhouse-driver==0.2.6]
+python_versions = <3.13
 
 [colorama==0.4.5]
 [colorama==0.4.6]
@@ -208,6 +221,7 @@ apt_requires =
     wget
 brew_requires = wget
 custom_prebuild = prebuild/librdkafka v2.1.1
+python_versions = <3.13
 [confluent-kafka==2.3.0]
 apt_requires =
     patch
@@ -221,14 +235,24 @@ custom_prebuild = prebuild/librdkafka v2.3.0
 [covdefaults==2.3.0]
 
 [coverage==6.3.3]
+python_versions = <3.13
 [coverage==6.4.1]
+python_versions = <3.13
 [coverage==6.4.3]
+python_versions = <3.13
 [coverage==6.4.4]
+python_versions = <3.13
 [coverage==6.5.0]
+python_versions = <3.13
 [coverage==7.1.0]
+python_versions = <3.13
 [coverage==7.2.7]
+python_versions = <3.13
 [coverage==7.3.4]
+python_versions = <3.13
 [coverage==7.4.1]
+python_versions = <3.13
+[coverage==7.6.4]
 
 [coverage-enable-subprocess==1.0]
 
@@ -470,6 +494,7 @@ validate_incorrect_missing_deps = six
 [gojsonnet==0.20.0]
 apt_requires = golang
 brew_requires = go
+python_versions = <3.13
 
 [google-api-core==1.32.0]
 [google-api-core==2.8.2]
@@ -595,12 +620,19 @@ python_versions = <3.12
 [grpcio==1.56.0]
 python_versions = <3.12
 [grpcio==1.59.0]
+python_versions = <3.13
 [grpcio==1.60.0]
+python_versions = <3.13
 [grpcio==1.60.1]
+python_versions = <3.13
 [grpcio==1.62.1]
+python_versions = <3.13
 [grpcio==1.64.0]
+python_versions = <3.13
 [grpcio==1.65.4]
+python_versions = <3.13
 [grpcio==1.66.1]
+python_versions = <3.13
 [grpcio==1.67.0]
 
 [grpcio-status==1.47.0]
@@ -625,6 +657,7 @@ python_versions = <3.12
 [hiredis==2.0.0]
 python_versions = <3.12
 [hiredis==2.3.2]
+python_versions = <3.13
 
 [honcho==1.0.0]
 [honcho==1.0.1]
@@ -710,6 +743,7 @@ python_versions = <3.12
 [johen==0.1.5]
 
 [jsonnet==0.20.0]
+python_versions = <3.13
 
 [jsonpatch==1.33]
 
@@ -777,6 +811,7 @@ apt_requires =
 brew_requires =
     libxml2
     libxslt
+python_versions = <3.13
 
 [lxml-stubs==0.4.0]
 
@@ -842,13 +877,17 @@ brew_requires = libmaxminddb
 [msgpack==1.0.4]
 python_versions = <3.12
 [msgpack==1.0.7]
+python_versions = <3.13
 [msgpack==1.0.8]
+python_versions = <3.13
 [msgpack==1.1.0]
 
 [msgpack-types==0.2.0]
 
 [multidict==6.0.2]
+python_versions = <3.13
 [multidict==6.0.4]
+python_versions = <3.13
 [multidict==6.1.0]
 
 [mypy==0.971]
@@ -919,7 +958,9 @@ python_versions = <3.12
 [opentelemetry-proto==1.22.0]
 
 [orjson==3.10.0]
+python_versions = <3.13
 [orjson==3.10.3]
+python_versions = <3.13
 
 [outcome==1.2.0]
 [outcome==1.3.0.post0]
@@ -976,10 +1017,15 @@ python_versions = <3.12
 [pillow==9.5.0]
 python_versions = <3.12
 [pillow==10.0.0]
+python_versions = <3.13
 [pillow==10.0.1]
+python_versions = <3.13
 [pillow==10.1.0]
+python_versions = <3.13
 [pillow==10.2.0]
+python_versions = <3.13
 [pillow==10.3.0]
+python_versions = <3.13
 [pillow==10.4.0]
 
 [pip==22.1.2]
@@ -1089,6 +1135,12 @@ apt_requires = libpq-dev
 brew_requires =
     openssl@1.1
     postgresql
+python_versions = <3.13
+[psycopg2-binary==2.9.10]
+apt_requires = libpq-dev
+brew_requires =
+    openssl@1.1
+    postgresql
 
 [py==1.11.0]
 
@@ -1129,7 +1181,10 @@ brew_requires =
 [pydantic==2.7.4]
 
 [pydantic-core==2.14.5]
+python_versions = <3.13
 [pydantic-core==2.18.4]
+python_versions = <3.13
+[pydantic-core==2.24.2]
 
 [pyelftools==0.28]
 [pyelftools==0.29]
@@ -1164,7 +1219,9 @@ brew_requires = libmemcached
 [pyproject-hooks==1.0.0]
 
 [pyrsistent==0.18.1]
+python_versions = <3.13
 [pyrsistent==0.19.3]
+python_versions = <3.13
 
 [pysocks==1.7.1]
 
@@ -1286,12 +1343,16 @@ brew_requires = libmemcached
 [pyupgrade==3.17.0]
 
 [pyuwsgi==2.0.23]
+python_versions = <3.13
 validate_skip_imports = uwsgidecorators
 [pyuwsgi==2.0.23.post0]
+python_versions = <3.13
 validate_skip_imports = uwsgidecorators
 [pyuwsgi==2.0.26]
+python_versions = <3.13
 validate_skip_imports = uwsgidecorators
 [pyuwsgi==2.0.27a1]
+python_versions = <3.13
 validate_skip_imports = uwsgidecorators
 
 [pyvat==1.3.15]
@@ -1312,6 +1373,7 @@ python_versions = <3.12
 [pyyaml==6.0.1]
 apt_requires = libyaml-dev
 brew_requires = libyaml
+python_versions = <3.13
 [pyyaml==6.0.2]
 apt_requires = libyaml-dev
 brew_requires = libyaml
@@ -1383,8 +1445,11 @@ python_versions = <3.12
 [rich==13.8.1]
 
 [rpds-py==0.9.2]
+python_versions = <3.13
 [rpds-py==0.13.1]
+python_versions = <3.13
 [rpds-py==0.15.2]
+python_versions = <3.13
 [rpds-py==0.20.0]
 
 [rq==1.0]
@@ -1991,6 +2056,7 @@ python_versions = >=3.10
 validate_skip_imports = slack
 
 [slipcover==1.0.3]
+python_versions = <3.13
 
 [smmap==3.0.2]
 [smmap==4.0.0]
@@ -2145,9 +2211,14 @@ python_versions = <3.12
 [tabulate==0.9.0]
 
 [tiktoken==0.6.0]
+python_versions = <3.13
+[tiktoken==0.8.0]
 
 [time-machine==2.12.0]
+python_versions = <3.13
 [time-machine==2.13.0]
+python_versions = <3.13
+[time-machine==2.16.0]
 
 [tldextract==5.1.2]
 
@@ -2415,7 +2486,9 @@ python_versions = <3.12
 [wheel==0.42.0]
 
 [wrapt==1.14.1]
+python_versions = <3.13
 [wrapt==1.16.0]
+python_versions = <3.13
 
 [wsproto==1.1.0]
 [wsproto==1.2.0]
@@ -2431,6 +2504,7 @@ brew_requires =
     openssl@1.1
     pkg-config
 custom_prebuild = prebuild/libxmlsec1-macos
+python_versions = <3.13
 
 [yamlfix==1.3.0]
 
@@ -2441,6 +2515,7 @@ python_versions = <3.12
 [yarl==1.9.2]
 python_versions = <3.12
 [yarl==1.9.4]
+python_versions = <3.13
 [yarl==1.15.4]
 
 [zipp==3.5.0]

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -43,24 +43,24 @@ def test_pythons_to_check_no_pythons_raises_error():
 
 def test_pythons_to_check_py2_ignored():
     ret = validate._pythons_to_check(parse_tag("py2.py3-none-any"))
-    assert ret == ("python3.11", "python3.12")
+    assert ret == ("python3.11", "python3.12", "python3.13")
 
 
 def test_pythons_to_check_py3_gives_all():
     ret = validate._pythons_to_check(parse_tag("py3-none-any"))
-    assert ret == ("python3.11", "python3.12")
+    assert ret == ("python3.11", "python3.12", "python3.13")
 
 
 def test_pythons_to_check_abi3():
     tag = "cp37-abi3-manylinux1_x86_64"
     ret = validate._pythons_to_check(parse_tag(tag))
-    assert ret == ("python3.11", "python3.12")
+    assert ret == ("python3.11", "python3.12", "python3.13")
 
 
 def test_pythons_to_check_minimum_abi3():
     tag = "cp312-abi3-manylinux1_x86_64"
     ret = validate._pythons_to_check(parse_tag(tag))
-    assert ret == ("python3.12",)
+    assert ret == ("python3.12", "python3.13")
 
 
 def test_pythons_to_check_specific_cpython_tag():

--- a/validate.py
+++ b/validate.py
@@ -15,7 +15,7 @@ from packaging.tags import Tag
 from packaging.utils import parse_wheel_filename
 from packaging.version import Version
 
-PYTHONS = ((3, 11), (3, 12))
+PYTHONS = ((3, 11), (3, 12), (3, 13))
 DIST_INFO_RE = re.compile(r"^[^/]+.dist-info/[^/]+$")
 
 


### PR DESCRIPTION
had to disable a lot of packages which either (1) didn't build or (2) produced purelib wheels when the rest were compiled -- will re-enable them in a followup