### PR TITLE
add h2

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -654,6 +654,8 @@ python_versions = <3.13
 [h11==0.13.0]
 [h11==0.14.0]
 
+[h2==4.1.0]
+
 [hiredis==0.3.1]
 python_versions = <3.12
 [hiredis==2.0.0]
@@ -665,6 +667,8 @@ python_versions = <3.13
 [honcho==1.0.1]
 [honcho==1.1.0]
 [honcho==2.0.0]
+
+[hpack==4.0.0]
 
 [httpcore==0.11.1]
 [httpcore==0.15.0]
@@ -678,6 +682,8 @@ python_versions = <3.13
 [httpx==0.25.2]
 [httpx==0.27.0]
 [httpx==0.27.2]
+
+[hyperframe==6.0.1]
 
 [hypothesis==6.61.0]
 validate_extras = pytest


### PR DESCRIPTION
Needed for HTTP2 support on the new sentry-python SDK
