### PR TITLE
Bump datadog to 0.51.0

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -159,6 +159,7 @@ python_versions = <3.12
 [certifi==2024.6.2]
 [certifi==2024.7.4]
 [certifi==2024.8.30]
+[certifi==2025.1.31]
 
 [cffi==1.14.6]
 apt_requires = libffi-dev
@@ -198,6 +199,7 @@ python_versions = <3.13
 [charset-normalizer==3.3.2]
 python_versions = <3.13
 [charset-normalizer==3.4.0]
+[charset-normalizer==3.4.1]
 
 [click==7.1.2]
 [click==8.0.4]
@@ -314,6 +316,7 @@ python_versions = <3.13
 [datadog==0.44.0]
 [datadog==0.46.0]
 [datadog==0.49.1]
+[datadog==0.51.0]
 
 [decorator==5.1.1]
 


### PR DESCRIPTION
We want to make use of being able to backdate timestamps for a metric we're writing, and this was introduced in 0.50.0