### PR TITLE
add latest drf-spectacular

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -49,6 +49,7 @@ python_versions = <3.13
 [attrs==23.1.0]
 [attrs==23.2.0]
 [attrs==24.2.0]
+[attrs==25.3.0]
 
 [auditwheel==5.1.2]
 
@@ -59,6 +60,8 @@ python_versions = <3.13
 [avro==1.11.1]
 
 [babel==2.10.3]
+
+[backports-zoneinfo==0.2.1]
 
 [bcrypt==4.0.0]
 [bcrypt==4.1.3]
@@ -391,6 +394,7 @@ validate_incorrect_missing_deps = six
 [django==4.2.7]
 [django==4.2.8]
 [django==4.2.11]
+[django==4.2.20]
 [django==5.0.1]
 [django==5.0.2]
 [django==5.0.3]
@@ -471,6 +475,7 @@ validate_incorrect_missing_deps = six
 [drf-spectacular==0.24.0]
 [drf-spectacular==0.26.3]
 [drf-spectacular==0.27.2]
+[drf-spectacular==0.28.0]
 
 [dumb-pypi==1.13.0]
 
@@ -786,6 +791,7 @@ python_versions = <3.12
 
 [importlib-resources==5.8.0]
 [importlib-resources==5.9.0]
+[importlib-resources==6.4.5]
 
 [inflection==0.5.1]
 
@@ -1567,6 +1573,7 @@ python_versions = <3.13
 [rpds-py==0.15.2]
 python_versions = <3.13
 [rpds-py==0.20.0]
+[rpds-py==0.20.1]
 
 [rq==1.0]
 
@@ -2858,5 +2865,6 @@ python_versions = <3.13
 [zipp==3.8.1]
 [zipp==3.12.0]
 [zipp==3.18.1]
+[zipp==3.20.2]
 
 [zstandard==0.18.0]


### PR DESCRIPTION
Ran `python3 -m add_pkg drf-spectacular==0.28.0` from following [docs here](https://develop.sentry.dev/development-infrastructure/python-dependencies/#adding-or-updating-a-dependency)
