### PR TITLE
add latest reportlab

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -1118,6 +1118,7 @@ python_versions = <3.13
 python_versions = <3.13
 [pillow==10.4.0]
 [pillow==11.0.0]
+[pillow==11.2.1]
 
 [pip==22.1.2]
 [pip==22.2.2]
@@ -1518,6 +1519,7 @@ python_versions = <3.12
 python_versions = <3.12
 [reportlab==4.0.7]
 [reportlab==4.2.5]
+[reportlab==4.4.0]
 
 [requests==2.25.1]
 [requests==2.27.1]


### PR DESCRIPTION
fixes a warning for NameConstant which will be removed in a future python version