### PR TITLE
add latest django-pg-zero-downtime-migrations

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -413,6 +413,7 @@ validate_incorrect_missing_deps = six
 [django==5.1.6]
 [django==5.1.7]
 [django==5.1.8]
+[django==5.2]
 
 [django-crispy-forms==1.14.0]
 
@@ -423,6 +424,7 @@ validate_incorrect_missing_deps = six
 [django-pg-zero-downtime-migrations==0.12]
 [django-pg-zero-downtime-migrations==0.13]
 [django-pg-zero-downtime-migrations==0.16]
+[django-pg-zero-downtime-migrations==0.18]
 
 [django-stubs==1.12.0]
 [django-stubs==1.15.0]
@@ -2780,6 +2782,7 @@ python_versions = <3.13
 [typing-extensions==4.12.0]
 [typing-extensions==4.12.2]
 [typing-extensions==4.13.0]
+[typing-extensions==4.13.2]
 
 [typing-inspect==0.7.1]
 [typing-inspect==0.8.0]


### PR DESCRIPTION
fixes drift related to `DEFERRABLE` in migration squashes