### PR TITLE
fix: switch github actions to workload identity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,9 @@ jobs:
     needs: [linux, macos]
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
@@ -64,8 +67,8 @@ jobs:
       with:
         path: dist
     - run: python3 -um make_index --pypi-url https://pypi.devinfra.sentry.io --dest index
-    - uses: google-github-actions/auth@v0
+    - uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
       with:
-        credentials_json: ${{ secrets.PYPI_DEVINFRA_SENTRY_IO }}
-    - run: yes | gcloud auth login --cred-file="$GOOGLE_APPLICATION_CREDENTIALS"
+        workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
+        service_account: gha-pypi@sac-prod-sa.iam.gserviceaccount.com
     - run: python3 -uS bin/upload-artifacts

--- a/packages.ini
+++ b/packages.ini
@@ -100,6 +100,8 @@ validate_extras = d
 validate_extras = d
 [black==24.10.0]
 validate_extras = d
+[black==25.1.0]
+validate_extras = d
 
 [blinker==1.4]
 [blinker==1.5]
@@ -1016,6 +1018,7 @@ python_versions = <3.13
 
 [mypy-extensions==0.4.3]
 [mypy-extensions==1.0.0]
+[mypy-extensions==1.1.0]
 
 [myst-parser==0.18.0]
 
@@ -1078,6 +1081,7 @@ python_versions = <3.13
 [packaging==24.0]
 [packaging==24.1]
 [packaging==24.2]
+[packaging==25.0]
 
 [paramiko==2.11.0]
 [paramiko==3.4.0]
@@ -1169,6 +1173,7 @@ python_versions = <3.13
 [platformdirs==4.2.0]
 [platformdirs==4.2.2]
 [platformdirs==4.3.6]
+[platformdirs==4.3.7]
 
 [pluggy==0.13.1]
 [pluggy==1.0.0]


### PR DESCRIPTION
Switch `collect-and-deploy` job to workload identity. This will allow us to get rid of static GCP credentials `GOOGLE_APPLICATION_CREDENTIALS`.