### PR TITLE
fix: switch github actions to workload identity, take 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,9 @@ jobs:
     needs: [linux, macos]
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
@@ -64,8 +67,8 @@ jobs:
       with:
         path: dist
     - run: python3 -um make_index --pypi-url https://pypi.devinfra.sentry.io --dest index
-    - uses: google-github-actions/auth@v0
+    - uses: google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193 # v2.1.10
       with:
-        credentials_json: ${{ secrets.PYPI_DEVINFRA_SENTRY_IO }}
-    - run: yes | gcloud auth login --cred-file="$GOOGLE_APPLICATION_CREDENTIALS"
+        workload_identity_provider: projects/868781662168/locations/global/workloadIdentityPools/prod-github/providers/github-oidc-pool
+        service_account: gha-pypi@sac-prod-sa.iam.gserviceaccount.com
     - run: python3 -uS bin/upload-artifacts

--- a/bin/upload-artifacts
+++ b/bin/upload-artifacts
@@ -6,9 +6,9 @@ import os.path
 import shlex
 import subprocess
 
-CACHE_ONE_HOUR = ("-h", "Cache-Control: public, max-age=3600")  # gcs default
-CACHE_FIVE_MINUTES = ("-h", "Cache-Control: public, max-age=300")
-CACHE_NO = ("-h", "Cache-Control: no-store")
+CACHE_ONE_HOUR = ("--cache-control", "public, max-age=3600")  # gcs default
+CACHE_FIVE_MINUTES = ("--cache-control", "public, max-age=300")
+CACHE_NO = ("--cache-control", "no-store")
 
 
 def main() -> int:
@@ -24,20 +24,20 @@ def main() -> int:
     cmds = (
         # upload wheels first before the index
         (
-            "gsutil",
-            *CACHE_ONE_HOUR,  # these are immutable so cache at default
-            "-m",  # parallel
+            "gcloud",
+            "storage",
             "cp",
             "-n",  # no-clobber
+            *CACHE_ONE_HOUR,  # these are immutable so cache at default
             os.path.join(args.index, "wheels", "*"),
             "gs://pypi.devinfra.sentry.io/wheels/",
         ),
         # upload the site parts in clobber mode (may be updating pages)
         (
-            "gsutil",
-            *CACHE_FIVE_MINUTES,  # shorter than default to make pip snappier
-            "-m",  # parallel
+            "gcloud",
+            "storage",
             "cp",
+            *CACHE_FIVE_MINUTES,  # shorter than default to make pip snappier
             "-r",  # recursive
             *(
                 os.path.join(args.index, name)
@@ -47,10 +47,11 @@ def main() -> int:
             "gs://pypi.devinfra.sentry.io",
         ),
         (
-            "gsutil",
+            "gcloud",
+            "storage",
+            "cp",
             # the packages.json file must be consistently read so no caching
             *CACHE_NO,
-            "cp",
             os.path.join(args.index, "packages.json"),
             "gs://pypi.devinfra.sentry.io",
         ),

--- a/packages.ini
+++ b/packages.ini
@@ -100,6 +100,8 @@ validate_extras = d
 validate_extras = d
 [black==24.10.0]
 validate_extras = d
+[black==25.1.0]
+validate_extras = d
 
 [blinker==1.4]
 [blinker==1.5]
@@ -1016,6 +1018,7 @@ python_versions = <3.13
 
 [mypy-extensions==0.4.3]
 [mypy-extensions==1.0.0]
+[mypy-extensions==1.1.0]
 
 [myst-parser==0.18.0]
 
@@ -1078,6 +1081,7 @@ python_versions = <3.13
 [packaging==24.0]
 [packaging==24.1]
 [packaging==24.2]
+[packaging==25.0]
 
 [paramiko==2.11.0]
 [paramiko==3.4.0]
@@ -1169,6 +1173,7 @@ python_versions = <3.13
 [platformdirs==4.2.0]
 [platformdirs==4.2.2]
 [platformdirs==4.3.6]
+[platformdirs==4.3.7]
 
 [pluggy==0.13.1]
 [pluggy==1.0.0]


### PR DESCRIPTION
Another attempt after https://github.com/getsentry/pypi/pull/1404

Switch `collect-and-deploy` job to workload identity. This will allow us to get rid of static GCP credentials `GOOGLE_APPLICATION_CREDENTIALS`.

Also replacing `gsutil` with the equivalent `gcloud storage` calls:
- Google recommends `gcloud storage` over `gsutil`: https://cloud.google.com/storage/docs/gsutil
- `gsutil` has an issue with picking up Workload Identity creds: https://stackoverflow.com/questions/49302859/gsutil-serviceexception-401-anonymous-caller-does-not-have-storage-objects-list