### PR TITLE
add_pkg google-genai==1.13.0 and upgrade openai==1.77.0

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -30,6 +30,7 @@ python_versions = <3.13
 [anyio==3.6.1]
 [anyio==3.7.1]
 [anyio==4.4.0]
+[anyio==4.9.0]
 
 [asgiref==3.5.2]
 [asgiref==3.6.0]
@@ -385,6 +386,7 @@ validate_incorrect_missing_deps = six
 
 [distro==1.5.0]
 [distro==1.8.0]
+[distro==1.9.0]
 
 [django==2.2.28]
 [django==3.0.14]
@@ -618,6 +620,7 @@ python_versions = <3.13
 [google-auth==2.35.0]
 [google-auth==2.38.0]
 [google-auth==2.39.0]
+[google-auth==2.40.0]
 
 [google-auth-httplib2==0.1.0]
 [google-auth-httplib2==0.2.0]
@@ -686,6 +689,8 @@ apt_requires = cmake
 brew_requires = cmake
 custom_prebuild = prebuild/crc32c 1.1.2
 
+[google-genai==1.13.0]
+
 [google-resumable-media==1.3.3]
 [google-resumable-media==2.3.3]
 [google-resumable-media==2.7.0]
@@ -750,6 +755,7 @@ python_versions = <3.13
 [h11==0.12.0]
 [h11==0.13.0]
 [h11==0.14.0]
+[h11==0.16.0]
 
 [h2==4.1.0]
 [h2==4.2.0]
@@ -774,6 +780,7 @@ python_versions = <3.12
 [httpcore==0.15.0]
 [httpcore==1.0.2]
 [httpcore==1.0.5]
+[httpcore==1.0.9]
 
 [httplib2==0.22.0]
 
@@ -782,6 +789,7 @@ python_versions = <3.12
 [httpx==0.25.2]
 [httpx==0.27.0]
 [httpx==0.27.2]
+[httpx==0.28.1]
 
 [hyperframe==6.0.1]
 [hyperframe==6.1.0]
@@ -845,6 +853,8 @@ python_versions = <3.12
 [jinja2==3.1.3]
 [jinja2==3.1.4]
 [jinja2==3.1.6]
+
+[jiter==0.9.0]
 
 [jmespath==0.10.0]
 [jmespath==1.0.1]
@@ -1059,6 +1069,7 @@ python_versions = <3.13
 [openai==0.27.0]
 [openai==0.27.8]
 [openai==1.3.5]
+[openai==1.77.0]
 
 [openapi-core==0.14.2]
 [openapi-core==0.15.0]
@@ -1321,12 +1332,14 @@ brew_requires =
 [pydantic==1.10.20]
 [pydantic==2.5.2]
 [pydantic==2.7.4]
+[pydantic==2.11.4]
 
 [pydantic-core==2.14.5]
 python_versions = <3.13
 [pydantic-core==2.18.4]
 python_versions = <3.13
 [pydantic-core==2.24.2]
+[pydantic-core==2.33.2]
 
 [pyelftools==0.28]
 [pyelftools==0.29]
@@ -2665,6 +2678,7 @@ python_versions = <3.13
 [tqdm==4.65.0]
 [tqdm==4.66.1]
 [tqdm==4.66.4]
+[tqdm==4.67.1]
 
 [trio==0.21.0]
 [trio==0.22.2]
@@ -2834,6 +2848,8 @@ python_versions = <3.13
 [typing-inspect==0.7.1]
 [typing-inspect==0.8.0]
 
+[typing-inspection==0.4.0]
+
 [tzdata==2022.1]
 [tzdata==2022.2]
 [tzdata==2023.3]
@@ -2910,6 +2926,8 @@ python_versions = <3.12
 [websocket-client==1.6.1]
 [websocket-client==1.6.4]
 [websocket-client==1.8.0]
+
+[websockets==15.0.1]
 
 [werkzeug==2.0.3]
 [werkzeug==2.1.2]


### PR DESCRIPTION
We need this package to use a new gemini model (flash 2.0 lite) for user feedback spam detection. The old model `text-bison` has been removed so we need this to fix the feature.

The only new dependency is `websockets`. It's only used by the `google.genai.live` module which we won't be using. To resolve a dependency conflict with `anyio`, this also upgrades `openai` to latest.