### PR TITLE
add opentelemetry-sdk

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -341,6 +341,7 @@ python_versions = <3.13
 
 [deprecated==1.2.13]
 [deprecated==1.2.14]
+[deprecated==1.2.18]
 
 [devservices==0.0.2]
 [devservices==0.0.3]
@@ -832,6 +833,7 @@ python_versions = <3.12
 [importlib-metadata==4.12.0]
 [importlib-metadata==6.0.0]
 [importlib-metadata==7.1.0]
+[importlib-metadata==8.6.1]
 
 [importlib-resources==5.8.0]
 [importlib-resources==5.9.0]
@@ -1097,8 +1099,14 @@ python_versions = <3.13
 [openapi-spec-validator==0.6.0]
 [openapi-spec-validator==0.7.1]
 
+[opentelemetry-api==1.32.1]
+
 [opentelemetry-proto==1.22.0]
 [opentelemetry-proto==1.32.1]
+
+[opentelemetry-sdk==1.32.1]
+
+[opentelemetry-semantic-conventions==0.53b1]
 
 [orjson==3.10.0]
 python_versions = <3.13
@@ -2967,6 +2975,7 @@ python_versions = <3.13
 python_versions = <3.13
 [wrapt==1.17.0rc1]
 [wrapt==1.17.0]
+[wrapt==1.17.2]
 
 [wsproto==1.1.0]
 [wsproto==1.2.0]
@@ -3004,5 +3013,6 @@ python_versions = <3.13
 [zipp==3.8.1]
 [zipp==3.12.0]
 [zipp==3.18.1]
+[zipp==3.21.0]
 
 [zstandard==0.18.0]


### PR DESCRIPTION
Python SDK 3.0 [depends on opentelemetry-sdk](https://github.com/getsentry/pypi/actions/runs/14903255641/job/41859806162?pr=1428)