### PR TITLE
Added dummy package for testing gradual sdk rollout

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -27,6 +27,8 @@ python_versions = <3.13
 [annotated-types==0.6.0]
 [annotated-types==0.7.0]
 
+[anton-testing-deleteme-123==3.0.0a1]
+
 [anyio==3.6.1]
 [anyio==3.7.1]
 [anyio==4.4.0]

--- a/packages.ini
+++ b/packages.ini
@@ -1104,13 +1104,16 @@ python_versions = <3.13
 [openapi-spec-validator==0.7.1]
 
 [opentelemetry-api==1.32.1]
+[opentelemetry-api==1.33.1]
 
 [opentelemetry-proto==1.22.0]
 [opentelemetry-proto==1.32.1]
 
 [opentelemetry-sdk==1.32.1]
+[opentelemetry-sdk==1.33.1]
 
 [opentelemetry-semantic-conventions==0.53b1]
+[opentelemetry-semantic-conventions==0.54b1]
 
 [orjson==3.10.0]
 python_versions = <3.13


### PR DESCRIPTION
Of course the name `anton-testing-deleteme-123` is not final. I just wanted to use a dummy name so in case something goes wrong we do not have a broken/abandoned package with a legit sounding sentry name on PyPI.