### PR TITLE
Update python-rapidjson to version 1.20

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -1501,6 +1501,7 @@ python_versions = <3.13
 [python-rapidjson==1.4]
 [python-rapidjson==1.8]
 [python-rapidjson==1.16]
+[python-rapidjson==1.20]
 
 [python-u2flib-server==5.0.0]
 [python-u2flib-server==5.0.1]


### PR DESCRIPTION
We have some systems like super big consumers using python-rapidjson 1.20.

