### PR TITLE
chore(setuptools): Bump to the patched version: 78.1.1

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -2588,6 +2588,7 @@ python_versions = >=3.10
 [setuptools==70.0.0]
 [setuptools==74.1.2]
 [setuptools==78.1.0]
+[setuptools==78.1.1]
 
 [setuptools-rust==1.5.2]
 


### PR DESCRIPTION
This fixes a path traversal vulnerability in PackageIndex.
See https://github.com/getsentry/relay/security/dependabot/106 for more info