### PR TITLE
deps: protobuf 5.29.5

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -1316,6 +1316,7 @@ python_versions = <3.13
 [protobuf==5.28.1]
 [protobuf==5.28.2]
 [protobuf==5.28.3]
+[protobuf==5.29.5]
 [protobuf==6.30.2]
 [protobuf==6.31.1]
 


### PR DESCRIPTION
Jumping to protobuf 6.31.1 has had a loooot of downstream impact, requiring a dozen other library version bumps. Going to break this up into smaller updates, first targeting the minimum version that resolves the vulnerability.