### PR TITLE
add uv_build==0.8.2

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -3103,6 +3103,8 @@ python_versions = <3.13
 
 [uv==0.8.2]
 
+[uv-build==0.8.2]
+
 [vine==1.3.0]
 [vine==5.0.0]
 [vine==5.1.0]


### PR DESCRIPTION
this is uv's build backend which is kind of like a very lightweight setuptools

using it in here to replace setup.py, also it does editable installs: https://github.com/getsentry/snuba/pull/7309
