### PR TITLE
add sentry-conventions==0.1.0

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -1923,6 +1923,8 @@ python_versions = <3.13
 [sentry-cli==2.50.0]
 [sentry-cli==2.50.2]
 
+[sentry-conventions==0.1.0]
+
 [sentry-covdefaults-disable-branch-coverage==1.0.2]
 
 [sentry-devenv==1.1.1]


### PR DESCRIPTION
This adds https://pypi.org/project/sentry-conventions/ which contains semantic conventions for spans, logs, etc. used across Sentry.