### PR TITLE
Add packages used by getsentry/launchpad

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -1,4 +1,5 @@
 [aiohappyeyeballs==2.4.3]
+[aiohappyeyeballs==2.6.1]
 
 [aiohttp==3.8.3]
 python_versions = <3.12
@@ -11,9 +12,11 @@ python_versions = <3.13
 [aiohttp==3.10.2]
 python_versions = <3.13
 [aiohttp==3.10.10]
+[aiohttp==3.12.15]
 
 [aiosignal==1.2.0]
 [aiosignal==1.3.1]
+[aiosignal==1.4.0]
 
 [alabaster==0.7.12]
 
@@ -40,6 +43,8 @@ python_versions = <3.13
 [asgiref==3.8.0]
 [asgiref==3.8.1]
 [asgiref==3.9.1]
+
+[asn1crypto==1.5.1]
 
 [async-generator==1.10]
 
@@ -139,6 +144,7 @@ python_versions = <3.12
 [build==0.8.0]
 [build==0.10.0]
 [build==1.0.3]
+[build==1.3.0]
 
 [cachetools==4.2.4]
 [cachetools==5.2.0]
@@ -150,6 +156,7 @@ python_versions = <3.12
 [cachetools==5.4.0]
 [cachetools==5.5.0]
 [cachetools==5.5.2]
+[cachetools==6.2.0]
 
 [celery==4.4.7]
 [celery==5.0.2]
@@ -199,6 +206,9 @@ python_versions = <3.13
 [cffi==1.17.1]
 apt_requires = libffi-dev
 brew_requires = libffi
+[cffi==2.0.0]
+apt_requires = libffi-dev
+brew_requires = libffi
 
 [cfgv==3.3.1]
 [cfgv==3.4.0]
@@ -234,6 +244,7 @@ python_versions = <3.13
 [click==8.1.8]
 [click==8.2.0]
 [click==8.2.1]
+[click==8.3.0]
 
 [click-didyoumean==0.3.0]
 [click-didyoumean==0.3.1]
@@ -271,6 +282,12 @@ apt_requires =
 brew_requires = wget
 custom_prebuild = prebuild/librdkafka v2.6.1
 [confluent-kafka==2.8.0]
+apt_requires =
+    patch
+    wget
+brew_requires = wget
+custom_prebuild = prebuild/librdkafka v2.8.0
+[confluent-kafka==2.9.0]
 apt_requires =
     patch
     wget
@@ -325,6 +342,7 @@ python_versions = <3.13
 [cryptography==43.0.1]
 [cryptography==44.0.1]
 [cryptography==44.0.2]
+[cryptography==46.0.2]
 
 [cssselect==1.0.3]
 [cssselect==1.1.0]
@@ -346,6 +364,7 @@ python_versions = <3.13
 [datadog==0.46.0]
 [datadog==0.49.1]
 [datadog==0.51.0]
+[datadog==0.52.1]
 
 [decorator==5.1.1]
 
@@ -558,6 +577,7 @@ validate_incorrect_missing_deps = psycopg2-binary
 
 [fastjsonschema==2.16.2]
 [fastjsonschema==2.20.0]
+[fastjsonschema==2.21.2]
 
 [fido2==0.9.2]
 [fido2==1.0.0]
@@ -614,6 +634,7 @@ validate_incorrect_missing_deps = psycopg2-binary
 
 [frozenlist==1.4.1]
 [frozenlist==1.5.0]
+[frozenlist==1.7.0]
 
 [fsspec==2025.9.0]
 
@@ -648,6 +669,7 @@ python_versions = <3.13
 [google-api-python-client==2.88.0]
 [google-api-python-client==2.137.0]
 [google-api-python-client==2.145.0]
+[google-api-python-client==2.181.0]
 
 [google-auth==1.29.0]
 [google-auth==1.35.0]
@@ -669,6 +691,7 @@ python_versions = <3.13
 [google-auth==2.39.0]
 [google-auth==2.40.0]
 [google-auth==2.40.3]
+[google-auth==2.41.1]
 
 [google-auth-httplib2==0.1.0]
 [google-auth-httplib2==0.2.0]
@@ -853,6 +876,7 @@ python_versions = <3.12
 [httpcore==1.0.9]
 
 [httplib2==0.22.0]
+[httplib2==0.31.0]
 
 [httpx==0.15.4]
 [httpx==0.23.0]
@@ -993,6 +1017,8 @@ python_versions = <3.13
 [lazy-object-proxy==1.9.0]
 [lazy-object-proxy==1.10.0]
 
+[lief==0.16.6]
+
 [looseversion==1.0.2]
 
 [lxml==4.9.1]
@@ -1021,6 +1047,8 @@ brew_requires =
 
 [lxml-stubs==0.4.0]
 
+[lzfse==0.4.2]
+
 [maison==1.4.0]
 
 [mako==1.1.4]
@@ -1032,6 +1060,7 @@ brew_requires =
 
 [markdown-it-py==2.1.0]
 [markdown-it-py==3.0.0]
+[markdown-it-py==4.0.0]
 
 [markupsafe==2.0.1]
 [markupsafe==2.1.1]
@@ -1099,6 +1128,7 @@ python_versions = <3.13
 [msgpack==1.0.8]
 python_versions = <3.13
 [msgpack==1.1.0]
+[msgpack==1.1.1]
 
 [msgpack-types==0.2.0]
 
@@ -1107,6 +1137,7 @@ python_versions = <3.13
 [multidict==6.0.4]
 python_versions = <3.13
 [multidict==6.1.0]
+[multidict==6.6.4]
 
 [mypy==0.971]
 [mypy==0.981]
@@ -1281,6 +1312,8 @@ python_versions = <3.13
 [pillow==11.2.1]
 [pillow==11.3.0]
 
+[pillow-heif==1.1.1]
+
 [pip==22.1.2]
 [pip==22.2.2]
 [pip==23.0.1]
@@ -1349,6 +1382,7 @@ python_versions = <3.13
 [prompt-toolkit==3.0.51]
 
 [propcache==0.2.0]
+[propcache==0.3.2]
 
 [proto-plus==1.20.4]
 [proto-plus==1.22.0]
@@ -1440,6 +1474,7 @@ brew_requires =
 
 [pycparser==2.21]
 [pycparser==2.22]
+[pycparser==2.23]
 
 [pycryptodomex==3.9.8]
 [pycryptodomex==3.19.1]
@@ -1452,6 +1487,7 @@ brew_requires =
 [pydantic==1.10.23]
 [pydantic==2.5.2]
 [pydantic==2.7.4]
+[pydantic==2.9.2]
 [pydantic==2.11.4]
 [pydantic==2.11.7]
 [pydantic==2.11.9]
@@ -1460,6 +1496,7 @@ brew_requires =
 python_versions = <3.13
 [pydantic-core==2.18.4]
 python_versions = <3.13
+[pydantic-core==2.23.4]
 [pydantic-core==2.24.2]
 [pydantic-core==2.33.2]
 
@@ -1498,8 +1535,10 @@ brew_requires = libmemcached
 [pyparsing==3.0.9]
 [pyparsing==3.1.2]
 [pyparsing==3.1.4]
+[pyparsing==3.2.5]
 
 [pyproject-hooks==1.0.0]
+[pyproject-hooks==1.2.0]
 
 [pyrsistent==0.18.1]
 python_versions = <3.13
@@ -1607,6 +1646,7 @@ python_versions = <3.13
 [python-rapidjson==1.8]
 [python-rapidjson==1.16]
 [python-rapidjson==1.20]
+[python-rapidjson==1.21]
 
 [python-u2flib-server==5.0.0]
 [python-u2flib-server==5.0.1]
@@ -1762,6 +1802,7 @@ python_versions = <3.12
 [rfc3986-validator==0.1.1]
 
 [rich==13.8.1]
+[rich==14.1.0]
 
 [rpds-py==0.9.2]
 python_versions = <3.13
@@ -3204,6 +3245,7 @@ python_versions = <3.13
 [unidiff==0.7.4]
 
 [uritemplate==4.1.1]
+[uritemplate==4.2.0]
 
 [urllib3==1.26.6]
 [urllib3==1.26.9]
@@ -3347,6 +3389,7 @@ python_versions = <3.12
 [yarl==1.9.4]
 python_versions = <3.13
 [yarl==1.15.4]
+[yarl==1.20.1]
 
 [zipp==3.5.0]
 [zipp==3.8.1]


### PR DESCRIPTION
Requirements taken from https://github.com/getsentry/launchpad/blob/main/requirements.txt.
In large part it is additional versions of existing packages however some of the notable additions are:
- lzfse - Apple compression format parsing
- asn1crypto - For parsing some app signatures
- pillow-heif  - .heif support for pillow
- lief - binary parsing (ELF, MachO, etc) library

Prerequisite for EME-213