### PR TITLE
Add sentry-seer-types==0.1.0

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -2961,6 +2961,8 @@ python_versions = >=3.10
 [sentry-sdk==3.0.0a6]
 [sentry-sdk==3.0.0a7]
 
+[sentry-seer-types==0.1.0]
+
 [sentry-streams==0.0.5]
 [sentry-streams==0.0.6]
 [sentry-streams==0.0.7]


### PR DESCRIPTION
## Summary
Adds sentry-seer-types package to internal PyPI for use in Sentry codebase.

## Package Details
- **Package**: sentry-seer-types==0.1.0  
- **Type**: Pure Python package (no build dependencies)
- **Purpose**: Shared Pydantic v1 models for Sentry-Seer code review integration

## Dependencies
All dependencies already available in internal PyPI:
- ✅ `pydantic==1.10.23` (already present)
- ✅ `typing-extensions>=4.0.0` (already present)

## Why This Package?
This package provides type-safe validation for code review requests between Sentry and Seer services, ensuring:
- Schema consistency between services
- Runtime validation catches payload errors before production
- Tests catch schema mismatches early
- Single source of truth for request/response models

## Testing
- 49 tests passing with 97% coverage
- All Pydantic v1 compatible
- No special build configuration needed

Made with [Cursor](https://cursor.com)