### PR TITLE
add mypy==1.20.1

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -1112,6 +1112,7 @@ python_versions = <3.13
 [lazy-object-proxy==1.10.0]
 
 [librt==0.7.8]
+[librt==0.9.0]
 
 [lief==0.16.6]
 python_versions = <3.14
@@ -1274,6 +1275,7 @@ python_versions = <3.13
 [mypy==1.18.2]
 [mypy==1.19.0]
 [mypy==1.19.1]
+[mypy==1.20.1]
 
 [mypy-extensions==0.4.3]
 [mypy-extensions==1.0.0]


### PR DESCRIPTION
## Summary
- Add mypy 1.20.1 (latest) to the registry
- Add librt 0.9.0 as a new dependency (mypy 1.20+ requires librt>=0.8.0; we only had 0.7.8)

## Test plan
- [ ] CI builds the new wheels successfully


Agent transcript: https://claudescope.sentry.dev/share/mA81DK1kHpqNL_1RNM7KBSudZ4Y0KfRXxG7z8FpUT1g