### PR TITLE
Remove taskbroker-client 26.5.0

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -3501,7 +3501,6 @@ python_versions = <3.12
 [taskbroker-client==0.1.8]
 [taskbroker-client==0.1.9]
 [taskbroker-client==0.1.10]
-[taskbroker-client==26.5.0]
 
 [tiktoken==0.6.0]
 python_versions = <3.13


### PR DESCRIPTION
ref STREAM-882

## Summary
- Remove taskbroker-client version 26.5.0 from packages.ini to prevent reintroduction

## Context
This version has an entirely wrong version scheme and collides with calver. We can't have it for taskbroker-client because its git tag in the repo would collide with the calver release of taskbroker next month (May 2026 = 26.5.x).

## Post-merge steps (per runbook/deleting.md)
After merging, the following manual GCS steps are needed:
1. Edit `packages.json` in GCS to remove the 26.5.0 entry
2. Edit `simple/taskbroker-client/index.html` to remove the version link
3. Delete the wheel: `gs://pypi.devinfra.sentry.io/wheels/taskbroker_client-26.5.0-py3-none-any.whl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)