### PR TITLE
build: Add mypy 1.20.2 to registry

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -1295,6 +1295,7 @@ python_versions = <3.13
 [mypy==1.19.0]
 [mypy==1.19.1]
 [mypy==1.20.1]
+[mypy==1.20.2]
 
 [mypy-extensions==0.4.3]
 [mypy-extensions==1.0.0]


### PR DESCRIPTION
Add mypy 1.20.2 to the internal package registry so Sentry can bump its dev dependency and regenerate uv.lock against the private index.

This is the prerequisite for updating Sentry from mypy 1.20.1 to 1.20.2.