### PR TITLE
add grpcio-tools 1.67.0

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -950,6 +950,9 @@ python_versions = <3.14
 [grpcio-status==1.75.1]
 python_versions = <3.14
 
+[grpcio-tools==1.67.0]
+python_versions = <3.14
+
 [h11==0.9.0]
 [h11==0.12.0]
 [h11==0.13.0]


### PR DESCRIPTION
## Summary

Add `grpcio-tools` to the private PyPI registry.

Needed for the [proto override system](https://github.com/getsentry/sentry/pull/115251) in sentry — compiles `.proto` files into `_pb2.py` modules during development (auto-compile on import) and CI builds (pre-compile for production).

All dependencies are already in the registry:
- `grpcio` (up to 1.75.1)
- `protobuf` (up to 6.31.1)
- `setuptools` (already present)

`grpcio-tools` ships pre-built wheels for macOS and Linux on Python 3.13, so no special build config should be needed (similar to `grpcio` which already works without `apt_requires`/`brew_requires` for recent versions).