### PR TITLE
build: Add mypy 2.1.0 to registry

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -49,6 +49,8 @@ python_versions = <3.13
 
 [asn1crypto==1.5.1]
 
+[ast-serialize==0.3.0]
+
 [async-generator==1.10]
 
 [async-timeout==4.0.2]
@@ -1138,6 +1140,7 @@ python_versions = <3.13
 
 [librt==0.7.8]
 [librt==0.9.0]
+[librt==0.11.0]
 
 [lief==0.16.6]
 python_versions = <3.14
@@ -1310,6 +1313,7 @@ python_versions = <3.13
 [mypy==1.19.1]
 [mypy==1.20.1]
 [mypy==1.20.2]
+[mypy==2.1.0]
 
 [mypy-extensions==0.4.3]
 [mypy-extensions==1.0.0]


### PR DESCRIPTION
Add mypy 2.1.0 to the internal package registry so Sentry can resolve the backend mypy upgrade from pypi.devinfra.

**Mypy Dependencies**

Mypy 2.1.0 adds dependencies on ast-serialize 0.3.0 and librt 0.11.0, so this registers those versions alongside the new mypy release.