### PR TITLE
chore: bump idna and ecdsa for snuba dependabot alerts

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -623,6 +623,7 @@ validate_incorrect_missing_deps = psycopg2-binary
 
 [ecdsa==0.18.0]
 [ecdsa==0.19.1]
+[ecdsa==0.19.2]
 
 [email-reply-parser==0.5.12]
 
@@ -1047,6 +1048,7 @@ validate_extras = pytest
 [idna==3.10]
 [idna==3.11]
 [idna==3.13]
+[idna==3.16]
 
 [imagesize==1.4.1]
 


### PR DESCRIPTION
## Summary

Adds two patched versions to the mirror so [snuba](https://github.com/getsentry/snuba) can clear two open dependabot alerts that are currently blocked by the mirror not having them yet.

| package | version added | snuba alert |
|---|---|---|
| `ecdsa` | `0.19.2` | [snuba #137](https://github.com/getsentry/snuba/security/dependabot/137) — DoS via improper DER length validation |
| `idna` | `3.16` | [snuba #165](https://github.com/getsentry/snuba/security/dependabot/165) — bypass of CVE-2024-3651 fix (patched at 3.15+) |

Once these wheels are built, snuba can `uv lock --upgrade-package idna --upgrade-package ecdsa` to pick them up. Tracked as a follow-up in https://github.com/getsentry/snuba/pull/7965.

## Test plan

- [ ] CI builds wheels for both packages on all supported python/platform combos


Agent transcript: https://claudescope.sentry.dev/share/XnLalBELPZKskOLzMLPK-UMt5q5XjJRUqZFP7_dQpE0