### PR TITLE
add google-re2==1.1.20251105

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -868,6 +868,8 @@ custom_prebuild = prebuild/crc32c 1.1.2
 
 [google-genai==1.13.0]
 
+[google-re2==1.1.20251105]
+
 [google-resumable-media==1.3.3]
 [google-resumable-media==2.3.3]
 [google-resumable-media==2.7.0]


### PR DESCRIPTION
Adds `google-re2` to the internal mirror so it can be used in `getsentry/sentry`.

**Why:** `getsentry/sentry#116427` adds client-supplied regex patterns for snapshot
image-name matching. Matching untrusted patterns with a backtracking engine (stdlib
`re` / the `regex` lib) is a ReDoS risk. RE2 is a linear-time engine — catastrophic
backtracking is impossible by construction, and it rejects backreferences/lookaround
at compile time (constructs we don't want for filename patterns anyway).

**Build notes:** empty section — upstream ships prebuilt `cp311`/`cp312`/`cp313`
abi-specific wheels for manylinux x86_64/aarch64 and macOS arm64/x86_64 (all our
targets), so no `apt_requires`/`brew_requires`/`custom_prebuild` is needed. No new
transitive deps (`add_pkg` resolved `google-re2` alone).

Follow-up: once this merges and the index deploys, the sentry PR pins
`google-re2>=1.1.20251105` and regenerates `uv.lock`.
