### PR TITLE
Add `grpcio-health-checking`

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -948,6 +948,9 @@ python_versions = <3.14
 [grpcio==1.73.1]
 python_versions = <3.14
 [grpcio==1.75.1]
+[grpcio==1.80.0]
+
+[grpcio-health-checking==1.80.0]
 
 [grpcio-status==1.47.0]
 [grpcio-status==1.48.1]
@@ -1633,6 +1636,7 @@ python_versions = <3.13
 [protobuf==6.30.2]
 [protobuf==6.31.1]
 [protobuf==6.32.1]
+[protobuf==6.33.6]
 [protobuf==7.34.1]
 
 [psutil==5.8.0]


### PR DESCRIPTION
In push mode, the Python taskworker runs a gRPC server. We need to add a gRPC readiness check in K8s so that taskworkers don't receive any tasks until they are fully up and running. We can easily achieve this using Google's `grpcio-health-checking` package.