### PR TITLE
Add `grpcio-health-checking` 1.67.1

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -950,6 +950,7 @@ python_versions = <3.14
 [grpcio==1.75.1]
 [grpcio==1.80.0]
 
+[grpcio-health-checking==1.67.1]
 [grpcio-health-checking==1.80.0]
 
 [grpcio-status==1.47.0]


### PR DESCRIPTION
Version 1.80.0 is too new and has some incompatibilities with our other libraries.