### PR TITLE
Add `kopf` 1.44.5

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -1,5 +1,6 @@
 [aiohappyeyeballs==2.4.3]
 [aiohappyeyeballs==2.6.1]
+[aiohappyeyeballs==2.6.2]
 
 [aiohttp==3.8.3]
 python_versions = <3.12
@@ -13,6 +14,7 @@ python_versions = <3.13
 python_versions = <3.13
 [aiohttp==3.10.10]
 [aiohttp==3.12.15]
+[aiohttp==3.14.0]
 
 [aiosignal==1.2.0]
 [aiosignal==1.3.1]
@@ -66,6 +68,7 @@ python_versions = <3.13
 [attrs==23.2.0]
 [attrs==24.2.0]
 [attrs==25.3.0]
+[attrs==26.1.0]
 
 [auditwheel==5.1.2]
 
@@ -266,6 +269,7 @@ python_versions = <3.13
 [click==8.2.1]
 [click==8.3.0]
 [click==8.3.1]
+[click==8.4.1]
 
 [click-didyoumean==0.3.0]
 [click-didyoumean==0.3.1]
@@ -718,6 +722,7 @@ validate_skip_imports = emmett_sentry
 [frozenlist==1.4.1]
 [frozenlist==1.5.0]
 [frozenlist==1.7.0]
+[frozenlist==1.8.0]
 
 [fsspec==2025.9.0]
 
@@ -1055,6 +1060,7 @@ validate_extras = pytest
 [idna==3.11]
 [idna==3.13]
 [idna==3.16]
+[idna==3.17]
 
 [imagesize==1.4.1]
 
@@ -1079,6 +1085,8 @@ python_versions = <3.12
 [iniconfig==2.3.0]
 
 [iso3166==2.1.1]
+
+[iso8601==2.1.0]
 
 [isodate==0.6.1]
 
@@ -1116,6 +1124,7 @@ python_versions = <3.13
 [jsonpath-ng==1.6.1]
 
 [jsonpointer==3.0.0]
+[jsonpointer==3.1.1]
 
 [jsonschema==3.2.0]
 [jsonschema==4.5.1]
@@ -1147,6 +1156,8 @@ python_versions = <3.13
 [kombu==5.3.6]
 [kombu==5.4.2]
 [kombu==5.5.3]
+
+[kopf==1.44.5]
 
 [kubernetes==19.15.0]
 [kubernetes==24.2.0]
@@ -1302,6 +1313,7 @@ python_versions = <3.13
 python_versions = <3.13
 [multidict==6.1.0]
 [multidict==6.6.4]
+[multidict==6.7.1]
 
 [mypy==0.971]
 [mypy==0.981]
@@ -1604,6 +1616,7 @@ python_versions = <3.13
 
 [propcache==0.2.0]
 [propcache==0.3.2]
+[propcache==0.5.2]
 
 [proto-plus==1.20.4]
 [proto-plus==1.22.0]
@@ -1884,6 +1897,8 @@ python_versions = <3.13
 [python-jose==3.3.0]
 [python-jose==3.4.0]
 [python-jose==3.5.0]
+
+[python-json-logger==4.1.0]
 
 [python-memcached==1.59]
 
@@ -4134,6 +4149,7 @@ python_versions = <3.12
 python_versions = <3.13
 [yarl==1.15.4]
 [yarl==1.20.1]
+[yarl==1.24.2]
 
 [zipp==3.5.0]
 [zipp==3.8.1]


### PR DESCRIPTION
Required to develop a Kubernetes operator for Kafka consumers.