### PR TITLE
fix(CI): add pytest-rerunfailures 16.3

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -1852,6 +1852,7 @@ python_versions = <3.13
 [pytest-rerunfailures==13.0]
 [pytest-rerunfailures==14.0]
 [pytest-rerunfailures==15.0]
+[pytest-rerunfailures==16.3]
 
 [pytest-sentry==0.1.9]
 [pytest-sentry==0.1.10]


### PR DESCRIPTION
Since pytest 8.1.2 → 9.0.3 landed in sentry (getsentry/sentry#115057, merged 2026-05-11 17:00 UTC), flaky backend tests whose fixture teardown fails have been poisoning their xdist worker: `pytest-rerunfailures` 

15.0 loses class-level teardown during reruns under pytest 9, stranding Django's `setUpClass` transaction on the shared connection, so every later test on the worker fails with `CrossTransactionAssertionError` (100-700 failures per job). We swept all failed `backend test` jobs on master back to April 10: 83 cascades, every one after the bump (the first just 83 minutes later), zero before.

Upstream acknowledged and fixed exactly this in [16.2](https://github.com/pytest-dev/pytest-rerunfailures/releases/tag/16.2), released two days after our bump: "Add support for pytest 9.0", with rerun teardown fixes [#314](https://github.com/pytest-dev/pytest-rerunfailures/issues/314) and [#323](https://github.com/pytest-dev/pytest-rerunfailures/issues/323). We're adding current 16.3 so sentry can bump its pin. 

Reproduced locally: pytest 9 + 15.0 reproduces the cascade, 16.3 is clean. Full RCA in [DI-2023.](https://linear.app/getsentry/issue/DI-2023/fix-crosstransactionassertionerror-cascade-poisoning-backend-test)