### PR TITLE
add clickhouse-connect==1.3.0

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -210,6 +210,7 @@ python_versions = <3.12
 [certifi==2026.1.4]
 [certifi==2026.2.25]
 [certifi==2026.4.22]
+[certifi==2026.6.17]
 
 [cffi==1.14.6]
 apt_requires = libffi-dev
@@ -278,6 +279,8 @@ python_versions = <3.13
 
 [click-repl==0.2.0]
 [click-repl==0.3.0]
+
+[clickhouse-connect==1.3.0]
 
 [clickhouse-driver==0.2.6]
 python_versions = <3.13
@@ -1220,6 +1223,8 @@ brew_requires =
     libxslt
 
 [lxml-stubs==0.4.0]
+
+[lz4==4.4.5]
 
 [lzfse==0.4.2]
 
@@ -4237,3 +4242,4 @@ python_versions = <3.13
 [zipp==3.23.0]
 
 [zstandard==0.18.0]
+[zstandard==0.25.0]


### PR DESCRIPTION
Adds the latest version of [`clickhouse-connect`](https://pypi.org/project/clickhouse-connect/) (`1.3.0`) to the mirror.

Generated via `python3 -m add_pkg clickhouse-connect`, which resolved and added the package along with its required dependencies that were not already present:

- `clickhouse-connect==1.3.0`
- `lz4==4.4.5` (new)
- `zstandard==0.25.0` (new version; `0.18.0` already present)
- `certifi==2026.6.17` (new version)

`urllib3` was already present and satisfied the requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S9BjcavgReK7TP53AL1U6F

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9BjcavgReK7TP53AL1U6F)_