### PR TITLE
Add types-redis==4.6

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -398,6 +398,7 @@ python_versions = <3.13
 [cryptography==46.0.5]
 [cryptography==46.0.7]
 [cryptography==47.0.0]
+[cryptography==49.0.0]
 
 [cssselect==1.0.3]
 [cssselect==1.1.0]
@@ -3900,6 +3901,8 @@ python_versions = <3.13
 [types-cachetools==5.3.0.6]
 [types-cachetools==5.3.0.7]
 
+[types-cffi==2.0.0.20260518]
+
 [types-croniter==1.3.2.9]
 [types-croniter==1.4.0.1]
 [types-croniter==2.0.0.0]
@@ -3957,6 +3960,7 @@ python_versions = <3.13
 
 [types-pyopenssl==23.0.0.4]
 [types-pyopenssl==23.2.0.2]
+[types-pyopenssl==24.1.0.20240722]
 
 [types-python-dateutil==2.8.19]
 [types-python-dateutil==2.8.19.8]
@@ -3991,6 +3995,7 @@ python_versions = <3.13
 [types-redis==4.3.20]
 [types-redis==4.5.1.3]
 [types-redis==4.6.0.3]
+[types-redis==4.6.0.20241004]
 
 [types-requests==2.28.8]
 [types-requests==2.28.9]
@@ -4013,6 +4018,7 @@ python_versions = <3.13
 [types-setuptools==68.0.0.3]
 [types-setuptools==69.0.0.0]
 [types-setuptools==74.1.0.20240907]
+[types-setuptools==82.0.0.20260518]
 
 [types-simplejson==3.17.7]
 [types-simplejson==3.17.7.1]


### PR DESCRIPTION
Adds typeshed package for redis 4.6.0 and its transitive dependencies.