### PR TITLE
perf(ci): Skip py3.14 builds for confluent-kafka 2.11.1 and sentry-streams 0.0.39

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -334,6 +334,7 @@ apt_requires =
     wget
 brew_requires = wget
 custom_prebuild = prebuild/librdkafka v2.8.0
+python_versions = <3.14
 [confluent-kafka==2.12.2]
 apt_requires =
     patch
@@ -3572,6 +3573,7 @@ python_versions = <3.14
 [sentry-streams==0.0.38]
 python_versions = <3.14
 [sentry-streams==0.0.39]
+python_versions = <3.14
 [sentry-streams==0.0.40]
 [sentry-streams==0.0.41]
 [sentry-streams==0.0.42]


### PR DESCRIPTION
`confluent-kafka==2.11.1` and `sentry-streams==0.0.39` have no official cp314 wheel on PyPI, so they never produce a 3.14 wheel — and every build wastes time failing to. This restricts both to `python_versions = <3.14`.

### Why they never build on 3.14

For 3.11–3.13 the builder downloads prebuilt PyPI wheels (cached, then skipped). For 3.14 it falls back to an sdist build that fails: sentry-streams 0.0.39 uses PyO3 0.24.0 (caps at 3.13, fails in ~1.3 min), and confluent-kafka 2.11.1 spends ~6.5 min compiling librdkafka + deps from source before failing the `librdkafka >= 2.11.1` check. The failed wheel never caches, so that work re-runs on every build.

### Why it's safe

This is version-specific, not a project-wide 3.14 drop: both projects support 3.14 in their next release (confluent-kafka 2.12.2+, sentry-streams 0.0.40+), and those cp314 wheels are already on the internal index. Matches the "skipped older versions" convention in `PYTHON-3.14-UPGRADE.md`.

### Impact

~8 min less per build. Confirmed on this PR's CI — linux amd64 dropped from ~8.7 min to ~0.5 min (arm64 ~7.4→0.6, macOS ~3.0→0.7). 

Since the build runs twice (on the PR, and on main) before a deploy, packages should now appear ~16 min sooner end to end.