### PR TITLE
Add flask-compress==1.24. Needed by snuba to compress query responses…

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -89,6 +89,8 @@ python_versions = <3.13
 
 [backports-zstd==1.3.0]
 python_versions = <3.14
+[backports-zstd==1.6.0]
+python_versions = <3.14
 
 [backrefs==5.9]
 
@@ -726,6 +728,8 @@ validate_skip_imports = emmett_sentry
 [flask==3.0.3]
 [flask==3.1.0]
 [flask==3.1.3]
+
+[flask-compress==1.24]
 
 [flask-redis==0.3.0]
 [flask-redis==0.4.0]
@@ -4335,6 +4339,7 @@ python_versions = <3.12
 [werkzeug==3.1.3]
 [werkzeug==3.1.5]
 [werkzeug==3.1.6]
+[werkzeug==3.1.8]
 
 [wheel==0.37.1]
 [wheel==0.38.4]


### PR DESCRIPTION
## What
Adds `flask-compress==1.24`, plus its resolved dependency `backports-zstd==1.6.0` 

Both are low-risk: 
- flask-compress is pure-Python (`py3-none-any`, no build config)
- backports-zstd==1.6.0 inherits the existing `python_versions = <3.14` constraint from 1.3.0.

## Why
snuba ([EAP-627](https://linear.app/getsentry/issue/EAP-627)) wants to compress query responses to cut Sentry x Snuba transfer size. Flask-Compress is the server-side middleware that enables this.