### PR TITLE
add clickhouse-connect==1.6.0

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -284,6 +284,7 @@ python_versions = <3.13
 [click-repl==0.3.0]
 
 [clickhouse-connect==1.3.0]
+[clickhouse-connect==1.6.0]
 
 [clickhouse-driver==0.2.6]
 python_versions = <3.13


### PR DESCRIPTION
## Summary
- Add `clickhouse-connect==1.6.0` (latest release on PyPI) to `packages.ini`, alongside the existing `1.3.0` entry.

## Test plan
- CI (`build.yml`) will build and validate the wheel for the new version on merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CA4nSw53ucoFabnujV4ACq)_