### PR TITLE
add pillow==12.3.0

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -1582,6 +1582,7 @@ python_versions = <3.13
 [pillow==11.3.0]
 [pillow==12.1.1]
 [pillow==12.2.0]
+[pillow==12.3.0]
 
 [pillow-heif==1.1.1]
 


### PR DESCRIPTION
Adds Pillow 12.3.0 to the internal package index so Sentry can bump its dependency.

Refs EME-1254
