### PR TITLE
chore: bump packages for sentry and snuba

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -48,6 +48,7 @@ python_versions = <3.13
 [asgiref==3.8.1]
 [asgiref==3.9.1]
 [asgiref==3.11.1]
+[asgiref==3.12.1]
 
 [asn1crypto==1.5.1]
 
@@ -232,6 +233,9 @@ brew_requires = libffi
 [cffi==2.0.0]
 apt_requires = libffi-dev
 brew_requires = libffi
+[cffi==2.1.1]
+apt_requires = libffi-dev
+brew_requires = libffi
 
 [cfgv==3.3.1]
 [cfgv==3.4.0]
@@ -410,6 +414,7 @@ python_versions = <3.13
 [cryptography==46.0.7]
 [cryptography==47.0.0]
 [cryptography==49.0.0]
+[cryptography==50.0.0]
 
 [cssselect==1.0.3]
 [cssselect==1.1.0]
@@ -554,6 +559,7 @@ validate_incorrect_missing_deps = six
 [django==5.2.12]
 [django==5.2.13]
 [django==5.2.14]
+[django==5.2.15]
 
 [django-crispy-forms==1.14.0]
 
@@ -1054,6 +1060,7 @@ python_versions = <3.12
 
 [httplib2==0.22.0]
 [httplib2==0.31.0]
+[httplib2==0.32.0]
 
 [httpx==0.15.4]
 [httpx==0.23.0]
@@ -1746,6 +1753,7 @@ brew_requires =
 [pyasn1==0.6.1]
 [pyasn1==0.6.2]
 [pyasn1==0.6.3]
+[pyasn1==0.6.4]
 
 [pyasn1-modules==0.2.4]
 [pyasn1-modules==0.2.8]
@@ -1843,6 +1851,7 @@ brew_requires = libmemcached
 [pyparsing==3.1.2]
 [pyparsing==3.1.4]
 [pyparsing==3.2.5]
+[pyparsing==3.3.2]
 
 [pyproject-hooks==1.0.0]
 [pyproject-hooks==1.2.0]
@@ -3721,6 +3730,7 @@ python_versions = <3.14
 [setuptools==78.1.1]
 [setuptools==80.9.0]
 [setuptools==80.10.2]
+[setuptools==83.0.0]
 
 [setuptools-rust==1.5.2]
 


### PR DESCRIPTION
```
cryptography==50.0.0
django==5.2.15
httplib2==0.32.0
pyasn1==0.6.4
setuptools==83.0.0
```