### PR TITLE
chore: Add sql-metadata 3.0.1

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -3854,9 +3854,12 @@ validate_incorrect_missing_deps = beautifulsoup4
 
 [sql-metadata==2.6.0]
 [sql-metadata==2.11.0]
+[sql-metadata==3.0.1]
 
 [sqlalchemy==1.4.41]
 python_versions = <3.12
+
+[sqlglot==30.16.0]
 
 [sqlparse==0.3.0]
 [sqlparse==0.4.2]


### PR DESCRIPTION
## Summary
- Add `sql-metadata==3.0.1` to the internal package index.
- Include resolved dependency `sqlglot==30.16.0` required by the new release.

## Testing
- `python3 -m add_pkg sql-metadata`
