### PR TITLE
add sentry-protos version

### DIFF
--- a/packages.ini
+++ b/packages.ini
@@ -3255,6 +3255,7 @@ python_versions = >=3.10
 [sentry-protos==0.62.1]
 [sentry-protos==0.62.2]
 [sentry-protos==0.62.3]
+[sentry-protos==0.63.0]
 
 [sentry-redis-tools==0.1.1]
 [sentry-redis-tools==0.1.2]


### PR DESCRIPTION
for some reason the release workflow did not update this 

https://github.com/getsentry/sentry-protos/releases/tag/0.63.0